### PR TITLE
fix: Summary display and AssemblyAI diarization fixes

### DIFF
--- a/src/lib/functions/assemblyai.function.ts
+++ b/src/lib/functions/assemblyai.function.ts
@@ -63,8 +63,14 @@ async function createTranscript(
     speaker_labels: true,
   };
 
-  if (language) {
+  // Handle language parameter:
+  // - "auto" or empty: use AssemblyAI's automatic language detection
+  // - specific code (en, es, fr, etc.): use that language
+  if (language && language !== "auto") {
     body.language_code = language;
+  } else {
+    // Enable automatic language detection when "auto" or not specified
+    body.language_detection = true;
   }
 
   if (speakersExpected && speakersExpected > 0) {

--- a/src/pages/context-memory/components/SummaryDetail.tsx
+++ b/src/pages/context-memory/components/SummaryDetail.tsx
@@ -21,6 +21,9 @@ import {
   Tag,
   Copy,
   Check,
+  Target,
+  ArrowRight,
+  MessageSquare,
 } from "lucide-react";
 import { updateMeetingSummary, getEntitiesForSummary } from "@/lib/database";
 import type { MeetingSummary, KnowledgeEntity } from "@/types";
@@ -328,6 +331,27 @@ export const SummaryDetail = ({
           </div>
         )}
 
+        {/* Goals */}
+        {summary.goals && summary.goals.length > 0 && (
+          <div className="space-y-2">
+            <Label className="flex items-center gap-2">
+              <Target className="h-3.5 w-3.5" />
+              Goals
+            </Label>
+            <ul className="space-y-1">
+              {summary.goals.map((goal, i) => (
+                <li
+                  key={i}
+                  className="text-sm text-muted-foreground flex items-start gap-2"
+                >
+                  <span className="text-muted-foreground/50">-</span>
+                  {goal}
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+
         {/* Action Items */}
         {summary.actionItems.length > 0 && (
           <div className="space-y-2">
@@ -349,6 +373,27 @@ export const SummaryDetail = ({
           </div>
         )}
 
+        {/* Next Steps */}
+        {summary.nextSteps && summary.nextSteps.length > 0 && (
+          <div className="space-y-2">
+            <Label className="flex items-center gap-2">
+              <ArrowRight className="h-3.5 w-3.5" />
+              Next Steps
+            </Label>
+            <ul className="space-y-1">
+              {summary.nextSteps.map((step, i) => (
+                <li
+                  key={i}
+                  className="text-sm text-muted-foreground flex items-start gap-2"
+                >
+                  <span className="text-muted-foreground/50">-</span>
+                  {step}
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+
         {/* Decisions */}
         {summary.decisions.length > 0 && (
           <div className="space-y-2">
@@ -364,6 +409,27 @@ export const SummaryDetail = ({
                 >
                   <span className="text-muted-foreground/50">-</span>
                   {decision}
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+
+        {/* Team Updates */}
+        {summary.teamUpdates && summary.teamUpdates.length > 0 && (
+          <div className="space-y-2">
+            <Label className="flex items-center gap-2">
+              <MessageSquare className="h-3.5 w-3.5" />
+              Team Updates
+            </Label>
+            <ul className="space-y-1">
+              {summary.teamUpdates.map((update, i) => (
+                <li
+                  key={i}
+                  className="text-sm text-muted-foreground flex items-start gap-2"
+                >
+                  <span className="text-muted-foreground/50">-</span>
+                  {update}
                 </li>
               ))}
             </ul>


### PR DESCRIPTION
## Summary

- Display missing summary fields (Goals, Next Steps, Team Updates) in Context Memory card UI
- Fix AssemblyAI diarization 400 error when language is set to "auto"

## Changes

### 1. Summary Display Fix
The SummaryDetail card UI was missing three sections that were only included in the markdown copy:
- **Goals** (with Target icon)
- **Next Steps** (with ArrowRight icon)  
- **Team Updates** (with MessageSquare icon)

### 2. AssemblyAI Diarization Fix
The default STT language setting is `"auto"`, but AssemblyAI doesn't accept `"auto"` as a valid `language_code` parameter, causing 400 Bad Request errors.

**Fix:** When language is `"auto"` or not specified, now uses `language_detection: true` instead of sending an invalid `language_code: "auto"`.

## Test Plan

- [ ] Verify Goals, Next Steps, and Team Updates appear in Context Memory summary detail view
- [ ] Verify speaker diarization works with default "auto" language setting
- [ ] Verify diarization works with specific language selected (e.g., "en")

🤖 Generated with [Claude Code](https://claude.com/claude-code)