### PR TITLE
feat: Add model dropdown selection with pricing and provider signup links

### DIFF
--- a/src/components/ModelSelector/index.tsx
+++ b/src/components/ModelSelector/index.tsx
@@ -1,0 +1,313 @@
+import { useState } from "react";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Input,
+} from "@/components";
+import { Header } from "@/components";
+import {
+  getAIModelsForProvider,
+  getSTTModelsForProvider,
+  hasModelsForProvider,
+  type ModelOption,
+} from "@/config/models.constants";
+import {
+  getModelPricing,
+  getSTTModelPricing,
+  formatCost,
+} from "@/lib/storage/pricing.storage";
+import { Star, Pencil } from "lucide-react";
+
+interface ModelSelectorProps {
+  providerId: string;
+  selectedModel: string;
+  onModelChange: (model: string) => void;
+  type: "ai" | "stt";
+  providerDisplayName?: string;
+}
+
+const CUSTOM_MODEL_VALUE = "__custom__";
+
+/**
+ * Format pricing for display in dropdown
+ */
+function formatAIPricing(providerId: string, modelId: string): string {
+  const pricing = getModelPricing(providerId, modelId);
+  if (pricing.inputPer1k === 0 && pricing.outputPer1k === 0) {
+    return "Free";
+  }
+  return `$${pricing.inputPer1k}/$${pricing.outputPer1k} per 1K`;
+}
+
+function formatSTTPricing(providerId: string, modelId: string): string {
+  const pricing = getSTTModelPricing(providerId, modelId);
+  if (pricing.perMinute === 0) {
+    return "Free";
+  }
+  if (pricing.perMinute < 0.001) {
+    return `$${pricing.perMinute.toFixed(5)}/min`;
+  }
+  return `$${pricing.perMinute.toFixed(4)}/min`;
+}
+
+/**
+ * Calculate estimated cost for typical usage
+ */
+function getEstimatedCost(
+  providerId: string,
+  modelId: string,
+  type: "ai" | "stt"
+): string {
+  if (type === "ai") {
+    const pricing = getModelPricing(providerId, modelId);
+    if (pricing.inputPer1k === 0 && pricing.outputPer1k === 0) {
+      return "Free (local model)";
+    }
+    // Estimate based on 500 input + 500 output tokens (typical request)
+    const inputCost = (500 / 1000) * pricing.inputPer1k;
+    const outputCost = (500 / 1000) * pricing.outputPer1k;
+    const totalCost = inputCost + outputCost;
+    return `~${formatCost(totalCost)} per typical request (500 in/out tokens)`;
+  } else {
+    const pricing = getSTTModelPricing(providerId, modelId);
+    if (pricing.perMinute === 0) {
+      return "Free (local model)";
+    }
+    return `~${formatCost(pricing.perMinute)} per minute of audio`;
+  }
+}
+
+export const ModelSelector = ({
+  providerId,
+  selectedModel,
+  onModelChange,
+  type,
+  providerDisplayName,
+}: ModelSelectorProps) => {
+  const [isCustomMode, setIsCustomMode] = useState(false);
+  const [customModelInput, setCustomModelInput] = useState("");
+
+  const models =
+    type === "ai"
+      ? getAIModelsForProvider(providerId)
+      : getSTTModelsForProvider(providerId);
+
+  const hasModels = hasModelsForProvider(providerId, type);
+
+  // Check if the current selected model is in the predefined list
+  const isSelectedModelPredefined =
+    hasModels && models.some((m) => m.id === selectedModel);
+
+  // If no predefined models, or we're in custom mode, show text input
+  if (!hasModels || isCustomMode) {
+    return (
+      <div className="space-y-2">
+        <Header
+          title="MODEL"
+          description={`Enter the model identifier for ${
+            providerDisplayName || providerId
+          }`}
+        />
+        <div className="flex gap-2">
+          <Input
+            type="text"
+            placeholder={`Enter model name (e.g., ${
+              type === "ai" ? "gpt-4o" : "whisper-1"
+            })`}
+            value={isCustomMode ? customModelInput : selectedModel}
+            onChange={(value) => {
+              const newValue =
+                typeof value === "string" ? value : value.target.value;
+              if (isCustomMode) {
+                setCustomModelInput(newValue);
+              }
+              onModelChange(newValue);
+            }}
+            className="flex-1 h-11 border-1 border-input/50 focus:border-primary/50 transition-colors"
+          />
+          {hasModels && isCustomMode && (
+            <button
+              onClick={() => {
+                setIsCustomMode(false);
+                setCustomModelInput("");
+              }}
+              className="px-3 h-11 text-sm bg-secondary hover:bg-secondary/80 rounded-md transition-colors"
+              title="Back to model list"
+            >
+              List
+            </button>
+          )}
+        </div>
+        {selectedModel && (
+          <div className="text-xs text-muted-foreground mt-1">
+            Estimated: {getEstimatedCost(providerId, selectedModel, type)}
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  // If selected model is not in predefined list but we have models, show as custom
+  const displayValue =
+    !isSelectedModelPredefined && selectedModel
+      ? CUSTOM_MODEL_VALUE
+      : selectedModel;
+
+  // Get the display name for the selected model
+  const getSelectedModelDisplay = () => {
+    if (!selectedModel) return null;
+
+    // If it's a custom model (not in predefined list)
+    if (!isSelectedModelPredefined) {
+      return (
+        <span className="flex items-center gap-2">
+          <Pencil className="h-3 w-3" />
+          {selectedModel}
+        </span>
+      );
+    }
+
+    // Find the model in the predefined list
+    const modelInfo = models.find((m) => m.id === selectedModel);
+    if (modelInfo) {
+      return (
+        <span className="flex items-center gap-2">
+          {modelInfo.recommended && <Star className="h-3 w-3 text-yellow-500" />}
+          {modelInfo.name}
+        </span>
+      );
+    }
+
+    return selectedModel;
+  };
+
+  return (
+    <div className="space-y-2">
+      <Header
+        title="MODEL"
+        description={`Select a model for ${
+          providerDisplayName || providerId
+        } or enter a custom model name`}
+      />
+      <Select
+        value={displayValue || ""}
+        onValueChange={(value) => {
+          if (value === CUSTOM_MODEL_VALUE) {
+            setIsCustomMode(true);
+            setCustomModelInput(selectedModel || "");
+          } else {
+            onModelChange(value);
+          }
+        }}
+      >
+        <SelectTrigger className="w-full h-11 border-1 border-input/50 focus:border-primary/50 transition-colors">
+          <SelectValue placeholder="Select a model">
+            {getSelectedModelDisplay()}
+          </SelectValue>
+        </SelectTrigger>
+        <SelectContent>
+          {/* Recommended models first */}
+          {models.filter((m) => m.recommended).length > 0 && (
+            <>
+              <div className="px-2 py-1 text-xs font-semibold text-muted-foreground">
+                Recommended
+              </div>
+              {models
+                .filter((m) => m.recommended)
+                .map((model) => (
+                  <ModelSelectItem
+                    key={model.id}
+                    model={model}
+                    providerId={providerId}
+                    type={type}
+                    showStar
+                  />
+                ))}
+            </>
+          )}
+
+          {/* Other models */}
+          {models.filter((m) => !m.recommended).length > 0 && (
+            <>
+              {models.filter((m) => m.recommended).length > 0 && (
+                <div className="border-t border-input/50 my-1" />
+              )}
+              <div className="px-2 py-1 text-xs font-semibold text-muted-foreground">
+                All Models
+              </div>
+              {models
+                .filter((m) => !m.recommended)
+                .map((model) => (
+                  <ModelSelectItem
+                    key={model.id}
+                    model={model}
+                    providerId={providerId}
+                    type={type}
+                  />
+                ))}
+            </>
+          )}
+
+          {/* Custom model option */}
+          <div className="border-t border-input/50 my-1" />
+          <SelectItem
+            value={CUSTOM_MODEL_VALUE}
+            className="cursor-pointer hover:bg-accent/50"
+          >
+            <span className="flex items-center gap-2">
+              <Pencil className="h-3 w-3" />
+              <span>Custom model...</span>
+            </span>
+          </SelectItem>
+        </SelectContent>
+      </Select>
+
+      {/* Cost estimation */}
+      {selectedModel && (
+        <div className="text-xs text-muted-foreground mt-1">
+          Estimated: {getEstimatedCost(providerId, selectedModel, type)}
+        </div>
+      )}
+    </div>
+  );
+};
+
+/**
+ * Individual model option in the select dropdown
+ */
+function ModelSelectItem({
+  model,
+  providerId,
+  type,
+  showStar = false,
+}: {
+  model: ModelOption;
+  providerId: string;
+  type: "ai" | "stt";
+  showStar?: boolean;
+}) {
+  const pricing =
+    type === "ai"
+      ? formatAIPricing(providerId, model.id)
+      : formatSTTPricing(providerId, model.id);
+
+  return (
+    <SelectItem
+      value={model.id}
+      className="cursor-pointer hover:bg-accent/50"
+    >
+      <div className="flex items-center justify-between w-full gap-4">
+        <div className="flex items-center gap-2 min-w-0">
+          {showStar && <Star className="h-3 w-3 text-yellow-500 flex-shrink-0" />}
+          <span className="font-medium truncate">{model.name}</span>
+        </div>
+        <span className="text-xs text-muted-foreground flex-shrink-0">
+          {pricing}
+        </span>
+      </div>
+    </SelectItem>
+  );
+}

--- a/src/components/ModelSelector/index.tsx
+++ b/src/components/ModelSelector/index.tsx
@@ -183,11 +183,7 @@ export const ModelSelector = ({
               type === "ai" ? "gpt-4o" : "whisper-1"
             })`}
             value={selectedModel}
-            onChange={(value) => {
-              const newValue =
-                typeof value === "string" ? value : value.target.value;
-              onModelChange(newValue);
-            }}
+            onChange={(e) => onModelChange(e.target.value)}
             className="flex-1 h-11 border-1 border-input/50 focus:border-primary/50 transition-colors"
           />
           {hasModels && isCustomMode && (

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -13,3 +13,4 @@ export * from "./Markdown/copy-button";
 export * from "./Icons";
 export * from "./SpeakerTaggingPopover";
 export * from "./WingIcon";
+export * from "./ModelSelector";

--- a/src/config/models.constants.ts
+++ b/src/config/models.constants.ts
@@ -175,8 +175,7 @@ export const AI_MODELS: Record<string, ModelOption[]> = {
     { id: "gpt-3.5-turbo", name: "GPT-3.5 Turbo", description: "Fast, cost-effective" },
   ],
   claude: [
-    { id: "claude-sonnet-4-20250514", name: "Claude Sonnet 4", recommended: true, description: "Latest and most capable" },
-    { id: "claude-3-5-sonnet-20241022", name: "Claude 3.5 Sonnet", description: "Excellent balance of speed and quality" },
+    { id: "claude-3-5-sonnet-20241022", name: "Claude 3.5 Sonnet", recommended: true, description: "Latest, excellent balance of speed and quality" },
     { id: "claude-3-opus-20240229", name: "Claude 3 Opus", description: "Highest capability" },
     { id: "claude-3-sonnet-20240229", name: "Claude 3 Sonnet", description: "Good balance" },
     { id: "claude-3-haiku-20240307", name: "Claude 3 Haiku", description: "Fastest, most affordable" },

--- a/src/config/models.constants.ts
+++ b/src/config/models.constants.ts
@@ -1,0 +1,309 @@
+/**
+ * Model configurations for AI and STT providers.
+ * Used to populate model dropdowns in the Dev Space settings.
+ */
+
+export interface ModelOption {
+  id: string;
+  name: string;
+  recommended?: boolean;
+  description?: string;
+}
+
+export interface ProviderInfo {
+  name: string;
+  signupUrl: string;
+  pricingUrl?: string;
+  description: string;
+}
+
+/**
+ * AI provider information including signup and pricing URLs.
+ */
+export const AI_PROVIDER_INFO: Record<string, ProviderInfo> = {
+  openai: {
+    name: "OpenAI",
+    signupUrl: "https://platform.openai.com/signup",
+    pricingUrl: "https://openai.com/api/pricing",
+    description: "Get your API key and credits from OpenAI",
+  },
+  claude: {
+    name: "Anthropic",
+    signupUrl: "https://console.anthropic.com/",
+    pricingUrl: "https://www.anthropic.com/pricing#anthropic-api",
+    description: "Get your API key and credits from Anthropic",
+  },
+  grok: {
+    name: "xAI",
+    signupUrl: "https://console.x.ai/",
+    pricingUrl: "https://x.ai/api",
+    description: "Get your API key from xAI",
+  },
+  gemini: {
+    name: "Google AI Studio",
+    signupUrl: "https://aistudio.google.com/apikey",
+    pricingUrl: "https://ai.google.dev/pricing",
+    description: "Get your API key from Google AI Studio",
+  },
+  mistral: {
+    name: "Mistral AI",
+    signupUrl: "https://console.mistral.ai/",
+    pricingUrl: "https://mistral.ai/technology/#pricing",
+    description: "Get your API key and credits from Mistral AI",
+  },
+  cohere: {
+    name: "Cohere",
+    signupUrl: "https://dashboard.cohere.com/welcome/register",
+    pricingUrl: "https://cohere.com/pricing",
+    description: "Get your API key and credits from Cohere",
+  },
+  groq: {
+    name: "Groq",
+    signupUrl: "https://console.groq.com/keys",
+    pricingUrl: "https://groq.com/pricing/",
+    description: "Get your API key from Groq (generous free tier!)",
+  },
+  perplexity: {
+    name: "Perplexity",
+    signupUrl: "https://www.perplexity.ai/settings/api",
+    pricingUrl: "https://docs.perplexity.ai/guides/pricing",
+    description: "Get your API key and credits from Perplexity",
+  },
+  openrouter: {
+    name: "OpenRouter",
+    signupUrl: "https://openrouter.ai/keys",
+    pricingUrl: "https://openrouter.ai/models",
+    description: "Access multiple AI providers through one API",
+  },
+  ollama: {
+    name: "Ollama",
+    signupUrl: "https://ollama.com/download",
+    description: "Download and run models locally for free",
+  },
+};
+
+/**
+ * STT provider information including signup and pricing URLs.
+ */
+export const STT_PROVIDER_INFO: Record<string, ProviderInfo> = {
+  "openai-whisper": {
+    name: "OpenAI Whisper",
+    signupUrl: "https://platform.openai.com/signup",
+    pricingUrl: "https://openai.com/api/pricing",
+    description: "Get your API key from OpenAI",
+  },
+  groq: {
+    name: "Groq Whisper",
+    signupUrl: "https://console.groq.com/keys",
+    pricingUrl: "https://groq.com/pricing/",
+    description: "Get your API key from Groq (very affordable!)",
+  },
+  "elevenlabs-stt": {
+    name: "ElevenLabs",
+    signupUrl: "https://elevenlabs.io/app/sign-up",
+    pricingUrl: "https://elevenlabs.io/pricing",
+    description: "Get your API key from ElevenLabs",
+  },
+  "google-stt": {
+    name: "Google Cloud Speech",
+    signupUrl: "https://console.cloud.google.com/apis/credentials",
+    pricingUrl: "https://cloud.google.com/speech-to-text/pricing",
+    description: "Get your API key from Google Cloud Console",
+  },
+  "deepgram-stt": {
+    name: "Deepgram",
+    signupUrl: "https://console.deepgram.com/signup",
+    pricingUrl: "https://deepgram.com/pricing",
+    description: "Get your API key from Deepgram",
+  },
+  "azure-stt": {
+    name: "Azure Speech Services",
+    signupUrl: "https://azure.microsoft.com/en-us/products/ai-services/speech-to-text",
+    pricingUrl: "https://azure.microsoft.com/en-us/pricing/details/cognitive-services/speech-services/",
+    description: "Get your API key from Azure Portal",
+  },
+  "speechmatics-stt": {
+    name: "Speechmatics",
+    signupUrl: "https://portal.speechmatics.com/signup",
+    pricingUrl: "https://www.speechmatics.com/pricing",
+    description: "Get your API key from Speechmatics",
+  },
+  "rev-ai-stt": {
+    name: "Rev.ai",
+    signupUrl: "https://www.rev.ai/auth/signup",
+    pricingUrl: "https://www.rev.ai/pricing",
+    description: "Get your API key from Rev.ai",
+  },
+  "ibm-watson-stt": {
+    name: "IBM Watson",
+    signupUrl: "https://cloud.ibm.com/catalog/services/speech-to-text",
+    pricingUrl: "https://www.ibm.com/products/speech-to-text/pricing",
+    description: "Get your API key from IBM Cloud",
+  },
+  "assemblyai-diarization": {
+    name: "AssemblyAI",
+    signupUrl: "https://www.assemblyai.com/app/signup",
+    pricingUrl: "https://www.assemblyai.com/pricing",
+    description: "Get your API key from AssemblyAI",
+  },
+};
+
+/**
+ * Get provider info for an AI provider.
+ */
+export function getAIProviderInfo(providerId: string): ProviderInfo | null {
+  return AI_PROVIDER_INFO[providerId] || null;
+}
+
+/**
+ * Get provider info for an STT provider.
+ */
+export function getSTTProviderInfo(providerId: string): ProviderInfo | null {
+  return STT_PROVIDER_INFO[providerId] || null;
+}
+
+/**
+ * AI model options per provider.
+ * Models are ordered by recommendation/popularity.
+ */
+export const AI_MODELS: Record<string, ModelOption[]> = {
+  openai: [
+    { id: "gpt-4o", name: "GPT-4 Omni", recommended: true, description: "Most capable, multimodal" },
+    { id: "gpt-4o-mini", name: "GPT-4 Omni Mini", description: "Fast and affordable" },
+    { id: "gpt-4-turbo", name: "GPT-4 Turbo", description: "High capability, faster than GPT-4" },
+    { id: "gpt-4", name: "GPT-4", description: "Original GPT-4" },
+    { id: "gpt-3.5-turbo", name: "GPT-3.5 Turbo", description: "Fast, cost-effective" },
+  ],
+  claude: [
+    { id: "claude-sonnet-4-20250514", name: "Claude Sonnet 4", recommended: true, description: "Latest and most capable" },
+    { id: "claude-3-5-sonnet-20241022", name: "Claude 3.5 Sonnet", description: "Excellent balance of speed and quality" },
+    { id: "claude-3-opus-20240229", name: "Claude 3 Opus", description: "Highest capability" },
+    { id: "claude-3-sonnet-20240229", name: "Claude 3 Sonnet", description: "Good balance" },
+    { id: "claude-3-haiku-20240307", name: "Claude 3 Haiku", description: "Fastest, most affordable" },
+  ],
+  grok: [
+    { id: "grok-2", name: "Grok 2", recommended: true, description: "Most capable xAI model" },
+    { id: "grok-2-mini", name: "Grok 2 Mini", description: "Fast and affordable" },
+    { id: "grok-beta", name: "Grok Beta", description: "Beta version" },
+  ],
+  gemini: [
+    { id: "gemini-1.5-pro", name: "Gemini 1.5 Pro", recommended: true, description: "Best quality, long context" },
+    { id: "gemini-1.5-flash", name: "Gemini 1.5 Flash", description: "Fast and affordable" },
+    { id: "gemini-pro", name: "Gemini Pro", description: "Standard Gemini model" },
+  ],
+  mistral: [
+    { id: "mistral-large-latest", name: "Mistral Large", recommended: true, description: "Most capable" },
+    { id: "mistral-medium-latest", name: "Mistral Medium", description: "Balanced performance" },
+    { id: "mistral-small-latest", name: "Mistral Small", description: "Fast and efficient" },
+    { id: "open-mixtral-8x22b", name: "Mixtral 8x22B", description: "Open-source MoE model" },
+    { id: "open-mixtral-8x7b", name: "Mixtral 8x7B", description: "Open-source MoE model" },
+  ],
+  cohere: [
+    { id: "command-r-plus", name: "Command R+", recommended: true, description: "Most capable" },
+    { id: "command-r", name: "Command R", description: "Balanced performance" },
+  ],
+  groq: [
+    { id: "llama-3.3-70b-versatile", name: "Llama 3.3 70B", recommended: true, description: "Latest Llama, versatile" },
+    { id: "llama-3.3-70b-specdec", name: "Llama 3.3 70B SpecDec", description: "Speculative decoding" },
+    { id: "llama-3.1-70b-versatile", name: "Llama 3.1 70B", description: "Large, capable model" },
+    { id: "llama-3.1-8b-instant", name: "Llama 3.1 8B", description: "Fast, efficient" },
+    { id: "llama-3.2-90b-vision-preview", name: "Llama 3.2 90B Vision", description: "Multimodal" },
+    { id: "llama-3.2-11b-vision-preview", name: "Llama 3.2 11B Vision", description: "Multimodal, efficient" },
+    { id: "mixtral-8x7b-32768", name: "Mixtral 8x7B", description: "Open-source MoE" },
+    { id: "gemma2-9b-it", name: "Gemma 2 9B", description: "Google's open model" },
+  ],
+  perplexity: [
+    { id: "llama-3.1-sonar-large-128k-online", name: "Sonar Large", recommended: true, description: "Best quality with web search" },
+    { id: "llama-3.1-sonar-small-128k-online", name: "Sonar Small", description: "Fast with web search" },
+    { id: "llama-3.1-sonar-large-128k-chat", name: "Sonar Large Chat", description: "No web search" },
+    { id: "llama-3.1-sonar-small-128k-chat", name: "Sonar Small Chat", description: "Fast, no web search" },
+  ],
+  openrouter: [
+    { id: "openai/gpt-4o", name: "OpenAI GPT-4o", recommended: true, description: "Via OpenRouter" },
+    { id: "anthropic/claude-3.5-sonnet", name: "Claude 3.5 Sonnet", description: "Via OpenRouter" },
+    { id: "meta-llama/llama-3.1-70b-instruct", name: "Llama 3.1 70B", description: "Via OpenRouter" },
+    { id: "google/gemini-pro-1.5", name: "Gemini 1.5 Pro", description: "Via OpenRouter" },
+    { id: "mistralai/mistral-large", name: "Mistral Large", description: "Via OpenRouter" },
+  ],
+  ollama: [
+    { id: "llama3.2", name: "Llama 3.2", recommended: true, description: "Latest Llama" },
+    { id: "llama3.1", name: "Llama 3.1", description: "Popular choice" },
+    { id: "mistral", name: "Mistral", description: "Fast and capable" },
+    { id: "codellama", name: "Code Llama", description: "Optimized for code" },
+    { id: "phi3", name: "Phi-3", description: "Microsoft small model" },
+    { id: "gemma2", name: "Gemma 2", description: "Google's open model" },
+  ],
+};
+
+/**
+ * STT model options per provider.
+ * Models are ordered by recommendation/popularity.
+ */
+export const STT_MODELS: Record<string, ModelOption[]> = {
+  "openai-whisper": [
+    { id: "whisper-1", name: "Whisper V1", recommended: true, description: "Standard Whisper model" },
+    { id: "gpt-4o-transcribe", name: "GPT-4o Transcribe", description: "High accuracy transcription" },
+    { id: "gpt-4o-mini-transcribe", name: "GPT-4o Mini Transcribe", description: "Fast and affordable" },
+  ],
+  groq: [
+    { id: "whisper-large-v3", name: "Whisper Large V3", recommended: true, description: "Best accuracy" },
+    { id: "whisper-large-v3-turbo", name: "Whisper Large V3 Turbo", description: "Faster variant" },
+    { id: "distil-whisper-large-v3-en", name: "Distil Whisper (English)", description: "Fast, English only" },
+  ],
+  "elevenlabs-stt": [
+    { id: "scribe_v1", name: "Scribe V1", recommended: true, description: "ElevenLabs STT model" },
+  ],
+  "google-stt": [
+    { id: "default", name: "Default", recommended: true, description: "Google Cloud STT" },
+    { id: "latest_long", name: "Latest Long", description: "Optimized for long audio" },
+    { id: "latest_short", name: "Latest Short", description: "Optimized for short audio" },
+  ],
+  "deepgram-stt": [
+    { id: "nova-2", name: "Nova 2", recommended: true, description: "Latest, most accurate" },
+    { id: "nova", name: "Nova", description: "Previous generation" },
+    { id: "enhanced", name: "Enhanced", description: "Higher accuracy" },
+    { id: "base", name: "Base", description: "Standard accuracy" },
+  ],
+  "azure-stt": [
+    { id: "default", name: "Default", recommended: true, description: "Azure Speech Services" },
+  ],
+  "speechmatics-stt": [
+    { id: "default", name: "Default", recommended: true, description: "Speechmatics STT" },
+  ],
+  "rev-ai-stt": [
+    { id: "default", name: "Default", recommended: true, description: "Rev.ai STT" },
+  ],
+  "ibm-watson-stt": [
+    { id: "default", name: "Default", recommended: true, description: "IBM Watson STT" },
+  ],
+  "assemblyai-diarization": [
+    { id: "best", name: "Best", recommended: true, description: "Highest accuracy" },
+    { id: "nano", name: "Nano", description: "Fastest, lower cost" },
+  ],
+};
+
+/**
+ * Get models for a specific AI provider.
+ * Returns empty array if provider not found.
+ */
+export function getAIModelsForProvider(providerId: string): ModelOption[] {
+  return AI_MODELS[providerId] || [];
+}
+
+/**
+ * Get models for a specific STT provider.
+ * Returns empty array if provider not found.
+ */
+export function getSTTModelsForProvider(providerId: string): ModelOption[] {
+  return STT_MODELS[providerId] || [];
+}
+
+/**
+ * Check if a provider has predefined models.
+ */
+export function hasModelsForProvider(providerId: string, type: "ai" | "stt"): boolean {
+  if (type === "ai") {
+    return providerId in AI_MODELS && AI_MODELS[providerId].length > 0;
+  }
+  return providerId in STT_MODELS && STT_MODELS[providerId].length > 0;
+}

--- a/src/lib/storage/pricing.storage.ts
+++ b/src/lib/storage/pricing.storage.ts
@@ -18,6 +18,12 @@ export const DEFAULT_PRICING: PricingConfig = {
     "*": { inputPer1k: 0.002, outputPer1k: 0.008 }, // Default for unknown OpenAI models
   },
   claude: {
+    // Exact model IDs used in API
+    "claude-3-5-sonnet-20241022": { inputPer1k: 0.003, outputPer1k: 0.015 },
+    "claude-3-opus-20240229": { inputPer1k: 0.015, outputPer1k: 0.075 },
+    "claude-3-sonnet-20240229": { inputPer1k: 0.003, outputPer1k: 0.015 },
+    "claude-3-haiku-20240307": { inputPer1k: 0.00025, outputPer1k: 0.00125 },
+    // Pattern matches for partial names
     "claude-3-5-sonnet": { inputPer1k: 0.003, outputPer1k: 0.015 },
     "claude-3-opus": { inputPer1k: 0.015, outputPer1k: 0.075 },
     "claude-3-sonnet": { inputPer1k: 0.003, outputPer1k: 0.015 },
@@ -53,17 +59,38 @@ export const DEFAULT_PRICING: PricingConfig = {
     "*": { inputPer1k: 0.0001, outputPer1k: 0.0001 },
   },
   mistral: {
+    // Exact model IDs with -latest suffix
+    "mistral-large-latest": { inputPer1k: 0.004, outputPer1k: 0.012 },
+    "mistral-medium-latest": { inputPer1k: 0.0027, outputPer1k: 0.0081 },
+    "mistral-small-latest": { inputPer1k: 0.001, outputPer1k: 0.003 },
+    // Mixtral MoE models
+    "open-mixtral-8x22b": { inputPer1k: 0.002, outputPer1k: 0.006 },
+    "open-mixtral-8x7b": { inputPer1k: 0.0007, outputPer1k: 0.0007 },
+    // Pattern matches for partial names
     "mistral-large": { inputPer1k: 0.004, outputPer1k: 0.012 },
     "mistral-medium": { inputPer1k: 0.0027, outputPer1k: 0.0081 },
     "mistral-small": { inputPer1k: 0.001, outputPer1k: 0.003 },
     "*": { inputPer1k: 0.0004, outputPer1k: 0.0012 },
   },
   perplexity: {
+    // Online models (with web search)
+    "llama-3.1-sonar-large-128k-online": { inputPer1k: 0.001, outputPer1k: 0.001 },
+    "llama-3.1-sonar-small-128k-online": { inputPer1k: 0.0002, outputPer1k: 0.0002 },
+    // Chat models (no web search)
+    "llama-3.1-sonar-large-128k-chat": { inputPer1k: 0.001, outputPer1k: 0.001 },
+    "llama-3.1-sonar-small-128k-chat": { inputPer1k: 0.0002, outputPer1k: 0.0002 },
+    // Pattern matches
     "llama-3.1-sonar-large": { inputPer1k: 0.001, outputPer1k: 0.001 },
     "llama-3.1-sonar-small": { inputPer1k: 0.0002, outputPer1k: 0.0002 },
     "*": { inputPer1k: 0.001, outputPer1k: 0.001 },
   },
   openrouter: {
+    // Popular models via OpenRouter (pricing varies, these are estimates)
+    "openai/gpt-4o": { inputPer1k: 0.0025, outputPer1k: 0.01 },
+    "anthropic/claude-3.5-sonnet": { inputPer1k: 0.003, outputPer1k: 0.015 },
+    "meta-llama/llama-3.1-70b-instruct": { inputPer1k: 0.00059, outputPer1k: 0.00079 },
+    "google/gemini-pro-1.5": { inputPer1k: 0.00125, outputPer1k: 0.005 },
+    "mistralai/mistral-large": { inputPer1k: 0.004, outputPer1k: 0.012 },
     // OpenRouter has variable pricing, use a reasonable default
     "*": { inputPer1k: 0.001, outputPer1k: 0.003 },
   },
@@ -81,6 +108,12 @@ export const DEFAULT_PRICING: PricingConfig = {
   },
   ollama: {
     // Ollama is free (runs locally)
+    "llama3.2": { inputPer1k: 0, outputPer1k: 0 },
+    "llama3.1": { inputPer1k: 0, outputPer1k: 0 },
+    "mistral": { inputPer1k: 0, outputPer1k: 0 },
+    "codellama": { inputPer1k: 0, outputPer1k: 0 },
+    "phi3": { inputPer1k: 0, outputPer1k: 0 },
+    "gemma2": { inputPer1k: 0, outputPer1k: 0 },
     "*": { inputPer1k: 0, outputPer1k: 0 },
   },
   // Default for unknown providers
@@ -94,19 +127,52 @@ export const DEFAULT_PRICING: PricingConfig = {
  * Prices are in USD per minute of audio.
  */
 export const DEFAULT_STT_PRICING: STTPricingConfig = {
-  openai: {
+  // OpenAI Whisper (via openai-whisper provider ID)
+  "openai-whisper": {
     "whisper-1": { perMinute: 0.006 },
     "gpt-4o-mini-transcribe": { perMinute: 0.003 }, // Cheaper than Whisper!
     "gpt-4o-transcribe": { perMinute: 0.006 },
     "*": { perMinute: 0.006 },
   },
+  // Legacy key for backwards compatibility
+  openai: {
+    "whisper-1": { perMinute: 0.006 },
+    "gpt-4o-mini-transcribe": { perMinute: 0.003 },
+    "gpt-4o-transcribe": { perMinute: 0.006 },
+    "*": { perMinute: 0.006 },
+  },
+  // Groq Whisper (very affordable!)
   groq: {
-    // Groq Whisper is much cheaper!
     "whisper-large-v3": { perMinute: 0.000111 },
     "whisper-large-v3-turbo": { perMinute: 0.00004 },
     "distil-whisper-large-v3-en": { perMinute: 0.00002 },
     "*": { perMinute: 0.0001 },
   },
+  // ElevenLabs STT
+  "elevenlabs-stt": {
+    "scribe_v1": { perMinute: 0.01 }, // Estimate
+    "*": { perMinute: 0.01 },
+  },
+  // Google Cloud Speech-to-Text
+  "google-stt": {
+    "default": { perMinute: 0.006 },
+    "latest_long": { perMinute: 0.006 },
+    "latest_short": { perMinute: 0.006 },
+    "*": { perMinute: 0.006 },
+  },
+  // Legacy key for backwards compatibility
+  google: {
+    "*": { perMinute: 0.006 },
+  },
+  // Deepgram STT
+  "deepgram-stt": {
+    "nova-2": { perMinute: 0.0043 },
+    "nova": { perMinute: 0.0043 },
+    "enhanced": { perMinute: 0.0145 },
+    "base": { perMinute: 0.0125 },
+    "*": { perMinute: 0.0043 },
+  },
+  // Legacy key for backwards compatibility
   deepgram: {
     "nova-2": { perMinute: 0.0043 },
     "nova": { perMinute: 0.0043 },
@@ -114,20 +180,43 @@ export const DEFAULT_STT_PRICING: STTPricingConfig = {
     "base": { perMinute: 0.0125 },
     "*": { perMinute: 0.0043 },
   },
+  // Azure Speech Services
+  "azure-stt": {
+    "default": { perMinute: 0.01 },
+    "*": { perMinute: 0.01 },
+  },
+  // Legacy key for backwards compatibility
+  azure: {
+    "*": { perMinute: 0.01 },
+  },
+  // Speechmatics STT
+  "speechmatics-stt": {
+    "default": { perMinute: 0.012 }, // ~$0.72/hour
+    "*": { perMinute: 0.012 },
+  },
+  // Rev.ai STT
+  "rev-ai-stt": {
+    "default": { perMinute: 0.02 }, // $0.02/min for async
+    "*": { perMinute: 0.02 },
+  },
+  // IBM Watson STT
+  "ibm-watson-stt": {
+    "default": { perMinute: 0.02 }, // ~$0.02/min
+    "*": { perMinute: 0.02 },
+  },
+  // AssemblyAI (with diarization)
+  "assemblyai-diarization": {
+    "best": { perMinute: 0.00617 },
+    "nano": { perMinute: 0.002 },
+    "*": { perMinute: 0.00617 },
+  },
+  // Legacy key for backwards compatibility
   assemblyai: {
     "best": { perMinute: 0.00617 },
     "nano": { perMinute: 0.002 },
     "universal": { perMinute: 0.0025 },
-    "universal-diarization": { perMinute: 0.00283 }, // Universal + speaker labels ($0.00033 extra)
-    "*": { perMinute: 0.00283 }, // Default assumes diarization enabled
-  },
-  google: {
-    // Google Cloud Speech-to-Text
-    "*": { perMinute: 0.006 },
-  },
-  azure: {
-    // Azure Speech Services
-    "*": { perMinute: 0.01 },
+    "universal-diarization": { perMinute: 0.00283 },
+    "*": { perMinute: 0.00283 },
   },
   // Default for unknown STT providers
   "*": {

--- a/src/pages/dev/components/ai-configs/Providers.tsx
+++ b/src/pages/dev/components/ai-configs/Providers.tsx
@@ -1,8 +1,10 @@
-import { Button, Header, Input, Selection, TextInput } from "@/components";
+import { Button, Header, Input, Selection, TextInput, ModelSelector } from "@/components";
 import { UseSettingsReturn } from "@/types";
 import curl2Json, { ResultJSON } from "@bany/curl-to-json";
-import { KeyIcon, TrashIcon } from "lucide-react";
+import { KeyIcon, TrashIcon, ExternalLink } from "lucide-react";
 import { useEffect, useState } from "react";
+import { getAIProviderInfo } from "@/config/models.constants";
+import { openUrl } from "@tauri-apps/plugin-opener";
 
 export const Providers = ({
   allAiProviders,
@@ -76,6 +78,32 @@ export const Providers = ({
           description={`If you want to use different url or method, you can always create a custom provider.`}
         />
       ) : null}
+
+      {/* Provider signup/pricing links */}
+      {selectedAIProvider?.provider && !allAiProviders?.find(p => p?.id === selectedAIProvider?.provider)?.isCustom && (() => {
+        const providerInfo = getAIProviderInfo(selectedAIProvider.provider);
+        if (!providerInfo) return null;
+        return (
+          <div className="flex flex-wrap gap-2 py-2">
+            <button
+              onClick={() => openUrl(providerInfo.signupUrl)}
+              className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm bg-primary/10 hover:bg-primary/20 text-primary rounded-md transition-colors"
+            >
+              <ExternalLink className="h-3.5 w-3.5" />
+              Get API Key from {providerInfo.name}
+            </button>
+            {providerInfo.pricingUrl && (
+              <button
+                onClick={() => openUrl(providerInfo.pricingUrl!)}
+                className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm bg-secondary hover:bg-secondary/80 text-secondary-foreground rounded-md transition-colors"
+              >
+                <ExternalLink className="h-3.5 w-3.5" />
+                View Pricing
+              </button>
+            )}
+          </div>
+        );
+      })()}
 
       {findKeyAndValue("api_key") ? (
         <div className="space-y-2">
@@ -184,6 +212,39 @@ export const Providers = ({
               return selectedAIProvider.variables[variable.key] || "";
             };
 
+            const isModelVariable = variable?.key === "model";
+            const currentProvider = allAiProviders?.find(
+              (p) => p?.id === selectedAIProvider?.provider
+            );
+            const isCustomProvider = currentProvider?.isCustom;
+            const providerDisplayName = isCustomProvider
+              ? "Custom Provider"
+              : selectedAIProvider?.provider;
+
+            // Use ModelSelector for model variable if provider has predefined models
+            if (isModelVariable && !isCustomProvider && selectedAIProvider?.provider) {
+              return (
+                <div key={variable?.key}>
+                  <ModelSelector
+                    providerId={selectedAIProvider.provider}
+                    selectedModel={getVariableValue()}
+                    onModelChange={(model) => {
+                      if (!variable?.key || !selectedAIProvider) return;
+                      onSetSelectedAIProvider({
+                        ...selectedAIProvider,
+                        variables: {
+                          ...selectedAIProvider.variables,
+                          [variable.key]: model,
+                        },
+                      });
+                    }}
+                    type="ai"
+                    providerDisplayName={providerDisplayName}
+                  />
+                </div>
+              );
+            }
+
             return (
               <div className="space-y-1" key={variable?.key}>
                 <Header
@@ -191,22 +252,10 @@ export const Providers = ({
                   description={`add your preferred ${variable?.key?.replace(
                     /_/g,
                     " "
-                  )} for ${
-                    allAiProviders?.find(
-                      (p) => p?.id === selectedAIProvider?.provider
-                    )?.isCustom
-                      ? "Custom Provider"
-                      : selectedAIProvider?.provider
-                  }`}
+                  )} for ${providerDisplayName}`}
                 />
                 <TextInput
-                  placeholder={`Enter ${
-                    allAiProviders?.find(
-                      (p) => p?.id === selectedAIProvider?.provider
-                    )?.isCustom
-                      ? "Custom Provider"
-                      : selectedAIProvider?.provider
-                  } ${variable?.key?.replace(/_/g, " ") || "value"}`}
+                  placeholder={`Enter ${providerDisplayName} ${variable?.key?.replace(/_/g, " ") || "value"}`}
                   value={getVariableValue()}
                   onChange={(value) => {
                     if (!variable?.key || !selectedAIProvider) return;

--- a/src/pages/dev/components/ai-configs/Providers.tsx
+++ b/src/pages/dev/components/ai-configs/Providers.tsx
@@ -5,6 +5,18 @@ import { KeyIcon, TrashIcon, ExternalLink } from "lucide-react";
 import { useEffect, useState } from "react";
 import { getAIProviderInfo } from "@/config/models.constants";
 import { openUrl } from "@tauri-apps/plugin-opener";
+import { toast } from "sonner";
+
+const handleOpenUrl = async (url: string) => {
+  try {
+    await openUrl(url);
+  } catch (error) {
+    console.error("Failed to open URL:", error);
+    toast.error("Failed to open link", {
+      description: "Please try again or copy the URL manually.",
+    });
+  }
+};
 
 export const Providers = ({
   allAiProviders,
@@ -83,18 +95,19 @@ export const Providers = ({
       {selectedAIProvider?.provider && !allAiProviders?.find(p => p?.id === selectedAIProvider?.provider)?.isCustom && (() => {
         const providerInfo = getAIProviderInfo(selectedAIProvider.provider);
         if (!providerInfo) return null;
+        const { pricingUrl } = providerInfo;
         return (
           <div className="flex flex-wrap gap-2 py-2">
             <button
-              onClick={() => openUrl(providerInfo.signupUrl)}
+              onClick={() => handleOpenUrl(providerInfo.signupUrl)}
               className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm bg-primary/10 hover:bg-primary/20 text-primary rounded-md transition-colors"
             >
               <ExternalLink className="h-3.5 w-3.5" />
               Get API Key from {providerInfo.name}
             </button>
-            {providerInfo.pricingUrl && (
+            {pricingUrl && (
               <button
-                onClick={() => openUrl(providerInfo.pricingUrl!)}
+                onClick={() => handleOpenUrl(pricingUrl)}
                 className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm bg-secondary hover:bg-secondary/80 text-secondary-foreground rounded-md transition-colors"
               >
                 <ExternalLink className="h-3.5 w-3.5" />

--- a/src/pages/dev/components/stt-configs/Providers.tsx
+++ b/src/pages/dev/components/stt-configs/Providers.tsx
@@ -5,6 +5,18 @@ import { KeyIcon, TrashIcon, ExternalLink } from "lucide-react";
 import { useEffect, useState } from "react";
 import { getSTTProviderInfo } from "@/config/models.constants";
 import { openUrl } from "@tauri-apps/plugin-opener";
+import { toast } from "sonner";
+
+const handleOpenUrl = async (url: string) => {
+  try {
+    await openUrl(url);
+  } catch (error) {
+    console.error("Failed to open URL:", error);
+    toast.error("Failed to open link", {
+      description: "Please try again or copy the URL manually.",
+    });
+  }
+};
 
 export const Providers = ({
   allSttProviders,
@@ -83,18 +95,19 @@ export const Providers = ({
       {selectedSttProvider?.provider && !allSttProviders?.find(p => p?.id === selectedSttProvider?.provider)?.isCustom && (() => {
         const providerInfo = getSTTProviderInfo(selectedSttProvider.provider);
         if (!providerInfo) return null;
+        const { pricingUrl } = providerInfo;
         return (
           <div className="flex flex-wrap gap-2 py-2">
             <button
-              onClick={() => openUrl(providerInfo.signupUrl)}
+              onClick={() => handleOpenUrl(providerInfo.signupUrl)}
               className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm bg-primary/10 hover:bg-primary/20 text-primary rounded-md transition-colors"
             >
               <ExternalLink className="h-3.5 w-3.5" />
               Get API Key from {providerInfo.name}
             </button>
-            {providerInfo.pricingUrl && (
+            {pricingUrl && (
               <button
-                onClick={() => openUrl(providerInfo.pricingUrl!)}
+                onClick={() => handleOpenUrl(pricingUrl)}
                 className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm bg-secondary hover:bg-secondary/80 text-secondary-foreground rounded-md transition-colors"
               >
                 <ExternalLink className="h-3.5 w-3.5" />

--- a/src/pages/dev/components/stt-configs/Providers.tsx
+++ b/src/pages/dev/components/stt-configs/Providers.tsx
@@ -1,8 +1,10 @@
-import { Button, Header, Input, Selection, TextInput } from "@/components";
+import { Button, Header, Input, Selection, TextInput, ModelSelector } from "@/components";
 import { UseSettingsReturn } from "@/types";
 import curl2Json, { ResultJSON } from "@bany/curl-to-json";
-import { KeyIcon, TrashIcon } from "lucide-react";
+import { KeyIcon, TrashIcon, ExternalLink } from "lucide-react";
 import { useEffect, useState } from "react";
+import { getSTTProviderInfo } from "@/config/models.constants";
+import { openUrl } from "@tauri-apps/plugin-opener";
 
 export const Providers = ({
   allSttProviders,
@@ -76,6 +78,33 @@ export const Providers = ({
           description={`If you want to use different url or method, you can always create a custom provider.`}
         />
       ) : null}
+
+      {/* Provider signup/pricing links */}
+      {selectedSttProvider?.provider && !allSttProviders?.find(p => p?.id === selectedSttProvider?.provider)?.isCustom && (() => {
+        const providerInfo = getSTTProviderInfo(selectedSttProvider.provider);
+        if (!providerInfo) return null;
+        return (
+          <div className="flex flex-wrap gap-2 py-2">
+            <button
+              onClick={() => openUrl(providerInfo.signupUrl)}
+              className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm bg-primary/10 hover:bg-primary/20 text-primary rounded-md transition-colors"
+            >
+              <ExternalLink className="h-3.5 w-3.5" />
+              Get API Key from {providerInfo.name}
+            </button>
+            {providerInfo.pricingUrl && (
+              <button
+                onClick={() => openUrl(providerInfo.pricingUrl!)}
+                className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm bg-secondary hover:bg-secondary/80 text-secondary-foreground rounded-md transition-colors"
+              >
+                <ExternalLink className="h-3.5 w-3.5" />
+                View Pricing
+              </button>
+            )}
+          </div>
+        );
+      })()}
+
       {findKeyAndValue("api_key") ? (
         <div className="space-y-2">
           <Header
@@ -185,6 +214,39 @@ export const Providers = ({
               return selectedSttProvider.variables[variable.key] || "";
             };
 
+            const isModelVariable = variable?.key === "model";
+            const currentProvider = allSttProviders?.find(
+              (p) => p?.id === selectedSttProvider?.provider
+            );
+            const isCustomProvider = currentProvider?.isCustom;
+            const providerDisplayName = isCustomProvider
+              ? "Custom Provider"
+              : currentProvider?.name || selectedSttProvider?.provider;
+
+            // Use ModelSelector for model variable if provider has predefined models
+            if (isModelVariable && !isCustomProvider && selectedSttProvider?.provider) {
+              return (
+                <div key={variable?.key}>
+                  <ModelSelector
+                    providerId={selectedSttProvider.provider}
+                    selectedModel={getVariableValue()}
+                    onModelChange={(model) => {
+                      if (!variable?.key || !selectedSttProvider) return;
+                      onSetSelectedSttProvider({
+                        ...selectedSttProvider,
+                        variables: {
+                          ...selectedSttProvider.variables,
+                          [variable.key]: model,
+                        },
+                      });
+                    }}
+                    type="stt"
+                    providerDisplayName={providerDisplayName}
+                  />
+                </div>
+              );
+            }
+
             return (
               <div className="space-y-1" key={variable?.key}>
                 <Header
@@ -192,22 +254,10 @@ export const Providers = ({
                   description={`add your preferred ${variable?.key?.replace(
                     /_/g,
                     " "
-                  )} for ${
-                    allSttProviders?.find(
-                      (p) => p?.id === selectedSttProvider?.provider
-                    )?.isCustom
-                      ? "Custom Provider"
-                      : selectedSttProvider?.provider
-                  }`}
+                  )} for ${providerDisplayName}`}
                 />
                 <TextInput
-                  placeholder={`Enter ${
-                    allSttProviders?.find(
-                      (p) => p?.id === selectedSttProvider?.provider
-                    )?.isCustom
-                      ? "Custom Provider"
-                      : selectedSttProvider?.provider
-                  } ${variable?.key?.replace(/_/g, " ") || "value"}`}
+                  placeholder={`Enter ${providerDisplayName} ${variable?.key?.replace(/_/g, " ") || "value"}`}
                   value={getVariableValue()}
                   onChange={(value) => {
                     if (!variable?.key || !selectedSttProvider) return;


### PR DESCRIPTION
## Summary
- Add **ModelSelector** component with dropdown for AI and STT models showing available models per provider
- Display **pricing per model** in dropdown (e.g., "$0.0025/$0.01 per 1K tokens")
- Show **cost estimation** below model selector based on typical usage
- Add **"Custom model..."** option for entering arbitrary model names
- Add **provider signup links** ("Get API Key from [Provider]") and pricing page buttons after provider selection

## Changes
- `src/components/ModelSelector/index.tsx` - New reusable model selector component
- `src/config/models.constants.ts` - Model catalogs and provider info (signup URLs, pricing URLs)
- `src/components/index.ts` - Export ModelSelector
- `src/pages/dev/components/ai-configs/Providers.tsx` - Use ModelSelector + provider links
- `src/pages/dev/components/stt-configs/Providers.tsx` - Use ModelSelector + provider links

## Screenshots
The Dev Space now shows:
- Model dropdown with recommended models marked with a star
- Pricing displayed inline for each model option
- Buttons to get API keys and view pricing for each provider

## Test plan
- [ ] Select an AI provider and verify model dropdown appears with models and pricing
- [ ] Select an STT provider and verify model dropdown appears with models and pricing
- [ ] Click "Get API Key from [Provider]" and verify it opens the correct signup page
- [ ] Click "View Pricing" and verify it opens the pricing page
- [ ] Select "Custom model..." and verify text input appears
- [ ] Verify cost estimation displays below model selector

🤖 Generated with [Claude Code](https://claude.com/claude-code)