### PR TITLE
feat: Add API verification flow and per-provider config storage

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -189,7 +189,7 @@ stop.bat         # Stop dev server
 | `/responses` | Responses | Response preferences |
 | `/cost-tracking` | Cost Tracking | API usage costs |
 | `/context-memory` | Context Memory | Knowledge base |
-| `/dev-space` | Dev Space | Developer tools |
+| `/api-setup` | API Setup | AI & Speech provider configuration |
 
 ## Code Style
 

--- a/src/components/ModelSelector/index.tsx
+++ b/src/components/ModelSelector/index.tsx
@@ -1,0 +1,313 @@
+import { useState } from "react";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Input,
+} from "@/components";
+import { Header } from "@/components";
+import {
+  getAIModelsForProvider,
+  getSTTModelsForProvider,
+  hasModelsForProvider,
+  type ModelOption,
+} from "@/config/models.constants";
+import {
+  getModelPricing,
+  getSTTModelPricing,
+  formatCost,
+} from "@/lib/storage/pricing.storage";
+import { Star, Pencil } from "lucide-react";
+
+interface ModelSelectorProps {
+  providerId: string;
+  selectedModel: string;
+  onModelChange: (model: string) => void;
+  type: "ai" | "stt";
+  providerDisplayName?: string;
+}
+
+const CUSTOM_MODEL_VALUE = "__custom__";
+
+/**
+ * Format pricing for display in dropdown
+ */
+function formatAIPricing(providerId: string, modelId: string): string {
+  const pricing = getModelPricing(providerId, modelId);
+  if (pricing.inputPer1k === 0 && pricing.outputPer1k === 0) {
+    return "Free";
+  }
+  return `$${pricing.inputPer1k}/$${pricing.outputPer1k} per 1K`;
+}
+
+function formatSTTPricing(providerId: string, modelId: string): string {
+  const pricing = getSTTModelPricing(providerId, modelId);
+  if (pricing.perMinute === 0) {
+    return "Free";
+  }
+  if (pricing.perMinute < 0.001) {
+    return `$${pricing.perMinute.toFixed(5)}/min`;
+  }
+  return `$${pricing.perMinute.toFixed(4)}/min`;
+}
+
+/**
+ * Calculate estimated cost for typical usage
+ */
+function getEstimatedCost(
+  providerId: string,
+  modelId: string,
+  type: "ai" | "stt"
+): string {
+  if (type === "ai") {
+    const pricing = getModelPricing(providerId, modelId);
+    if (pricing.inputPer1k === 0 && pricing.outputPer1k === 0) {
+      return "Free (local model)";
+    }
+    // Estimate based on 500 input + 500 output tokens (typical request)
+    const inputCost = (500 / 1000) * pricing.inputPer1k;
+    const outputCost = (500 / 1000) * pricing.outputPer1k;
+    const totalCost = inputCost + outputCost;
+    return `~${formatCost(totalCost)} per typical request (500 in/out tokens)`;
+  } else {
+    const pricing = getSTTModelPricing(providerId, modelId);
+    if (pricing.perMinute === 0) {
+      return "Free (local model)";
+    }
+    return `~${formatCost(pricing.perMinute)} per minute of audio`;
+  }
+}
+
+export const ModelSelector = ({
+  providerId,
+  selectedModel,
+  onModelChange,
+  type,
+  providerDisplayName,
+}: ModelSelectorProps) => {
+  const [isCustomMode, setIsCustomMode] = useState(false);
+  const [customModelInput, setCustomModelInput] = useState("");
+
+  const models =
+    type === "ai"
+      ? getAIModelsForProvider(providerId)
+      : getSTTModelsForProvider(providerId);
+
+  const hasModels = hasModelsForProvider(providerId, type);
+
+  // Check if the current selected model is in the predefined list
+  const isSelectedModelPredefined =
+    hasModels && models.some((m) => m.id === selectedModel);
+
+  // If no predefined models, or we're in custom mode, show text input
+  if (!hasModels || isCustomMode) {
+    return (
+      <div className="space-y-2">
+        <Header
+          title="MODEL"
+          description={`Enter the model identifier for ${
+            providerDisplayName || providerId
+          }`}
+        />
+        <div className="flex gap-2">
+          <Input
+            type="text"
+            placeholder={`Enter model name (e.g., ${
+              type === "ai" ? "gpt-4o" : "whisper-1"
+            })`}
+            value={isCustomMode ? customModelInput : selectedModel}
+            onChange={(value) => {
+              const newValue =
+                typeof value === "string" ? value : value.target.value;
+              if (isCustomMode) {
+                setCustomModelInput(newValue);
+              }
+              onModelChange(newValue);
+            }}
+            className="flex-1 h-11 border-1 border-input/50 focus:border-primary/50 transition-colors"
+          />
+          {hasModels && isCustomMode && (
+            <button
+              onClick={() => {
+                setIsCustomMode(false);
+                setCustomModelInput("");
+              }}
+              className="px-3 h-11 text-sm bg-secondary hover:bg-secondary/80 rounded-md transition-colors"
+              title="Back to model list"
+            >
+              List
+            </button>
+          )}
+        </div>
+        {selectedModel && (
+          <div className="text-xs text-muted-foreground mt-1">
+            Estimated: {getEstimatedCost(providerId, selectedModel, type)}
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  // If selected model is not in predefined list but we have models, show as custom
+  const displayValue =
+    !isSelectedModelPredefined && selectedModel
+      ? CUSTOM_MODEL_VALUE
+      : selectedModel;
+
+  // Get the display name for the selected model
+  const getSelectedModelDisplay = () => {
+    if (!selectedModel) return null;
+
+    // If it's a custom model (not in predefined list)
+    if (!isSelectedModelPredefined) {
+      return (
+        <span className="flex items-center gap-2">
+          <Pencil className="h-3 w-3" />
+          {selectedModel}
+        </span>
+      );
+    }
+
+    // Find the model in the predefined list
+    const modelInfo = models.find((m) => m.id === selectedModel);
+    if (modelInfo) {
+      return (
+        <span className="flex items-center gap-2">
+          {modelInfo.recommended && <Star className="h-3 w-3 text-yellow-500" />}
+          {modelInfo.name}
+        </span>
+      );
+    }
+
+    return selectedModel;
+  };
+
+  return (
+    <div className="space-y-2">
+      <Header
+        title="MODEL"
+        description={`Select a model for ${
+          providerDisplayName || providerId
+        } or enter a custom model name`}
+      />
+      <Select
+        value={displayValue || ""}
+        onValueChange={(value) => {
+          if (value === CUSTOM_MODEL_VALUE) {
+            setIsCustomMode(true);
+            setCustomModelInput(selectedModel || "");
+          } else {
+            onModelChange(value);
+          }
+        }}
+      >
+        <SelectTrigger className="w-full h-11 border-1 border-input/50 focus:border-primary/50 transition-colors">
+          <SelectValue placeholder="Select a model">
+            {getSelectedModelDisplay()}
+          </SelectValue>
+        </SelectTrigger>
+        <SelectContent>
+          {/* Recommended models first */}
+          {models.filter((m) => m.recommended).length > 0 && (
+            <>
+              <div className="px-2 py-1 text-xs font-semibold text-muted-foreground">
+                Recommended
+              </div>
+              {models
+                .filter((m) => m.recommended)
+                .map((model) => (
+                  <ModelSelectItem
+                    key={model.id}
+                    model={model}
+                    providerId={providerId}
+                    type={type}
+                    showStar
+                  />
+                ))}
+            </>
+          )}
+
+          {/* Other models */}
+          {models.filter((m) => !m.recommended).length > 0 && (
+            <>
+              {models.filter((m) => m.recommended).length > 0 && (
+                <div className="border-t border-input/50 my-1" />
+              )}
+              <div className="px-2 py-1 text-xs font-semibold text-muted-foreground">
+                All Models
+              </div>
+              {models
+                .filter((m) => !m.recommended)
+                .map((model) => (
+                  <ModelSelectItem
+                    key={model.id}
+                    model={model}
+                    providerId={providerId}
+                    type={type}
+                  />
+                ))}
+            </>
+          )}
+
+          {/* Custom model option */}
+          <div className="border-t border-input/50 my-1" />
+          <SelectItem
+            value={CUSTOM_MODEL_VALUE}
+            className="cursor-pointer hover:bg-accent/50"
+          >
+            <span className="flex items-center gap-2">
+              <Pencil className="h-3 w-3" />
+              <span>Custom model...</span>
+            </span>
+          </SelectItem>
+        </SelectContent>
+      </Select>
+
+      {/* Cost estimation */}
+      {selectedModel && (
+        <div className="text-xs text-muted-foreground mt-1">
+          Estimated: {getEstimatedCost(providerId, selectedModel, type)}
+        </div>
+      )}
+    </div>
+  );
+};
+
+/**
+ * Individual model option in the select dropdown
+ */
+function ModelSelectItem({
+  model,
+  providerId,
+  type,
+  showStar = false,
+}: {
+  model: ModelOption;
+  providerId: string;
+  type: "ai" | "stt";
+  showStar?: boolean;
+}) {
+  const pricing =
+    type === "ai"
+      ? formatAIPricing(providerId, model.id)
+      : formatSTTPricing(providerId, model.id);
+
+  return (
+    <SelectItem
+      value={model.id}
+      className="cursor-pointer hover:bg-accent/50"
+    >
+      <div className="flex items-center justify-between w-full gap-4">
+        <div className="flex items-center gap-2 min-w-0">
+          {showStar && <Star className="h-3 w-3 text-yellow-500 flex-shrink-0" />}
+          <span className="font-medium truncate">{model.name}</span>
+        </div>
+        <span className="text-xs text-muted-foreground flex-shrink-0">
+          {pricing}
+        </span>
+      </div>
+    </SelectItem>
+  );
+}

--- a/src/components/ModelSelector/index.tsx
+++ b/src/components/ModelSelector/index.tsx
@@ -183,11 +183,7 @@ export const ModelSelector = ({
               type === "ai" ? "gpt-4o" : "whisper-1"
             })`}
             value={selectedModel}
-            onChange={(value) => {
-              const newValue =
-                typeof value === "string" ? value : value.target.value;
-              onModelChange(newValue);
-            }}
+            onChange={(e) => onModelChange(e.target.value)}
             className="flex-1 h-11 border-1 border-input/50 focus:border-primary/50 transition-colors"
           />
           {hasModels && isCustomMode && (

--- a/src/components/ModelSelector/index.tsx
+++ b/src/components/ModelSelector/index.tsx
@@ -14,13 +14,7 @@ import {
   hasModelsForProvider,
   type ModelOption,
 } from "@/config/models.constants";
-import {
-  getModelPricing,
-  getSTTModelPricing,
-  formatCost,
-  getPricingConfig,
-  getSTTPricingConfig,
-} from "@/lib/storage/pricing.storage";
+import { usePricing, formatAIPricing, formatSTTPricing } from "@/hooks/usePricing";
 import { Star, Pencil, AlertCircle } from "lucide-react";
 
 interface ModelSelectorProps {
@@ -34,317 +28,91 @@ interface ModelSelectorProps {
 const CUSTOM_MODEL_VALUE = "__custom__";
 
 /**
- * Check if pricing for a model is using fallback/estimated values.
- * Returns true if using wildcard (*) pricing instead of exact model pricing.
+ * Cost estimation display component
  */
-function isUsingFallbackPricing(
-  providerId: string,
-  modelId: string,
-  type: "ai" | "stt"
-): boolean {
-  if (type === "ai") {
-    const config = getPricingConfig();
-    const providerPricing = config[providerId];
-    if (!providerPricing) return true; // Using provider wildcard
-    if (providerPricing[modelId]) return false; // Exact match found
-    // Check if any pattern matches
-    for (const pattern of Object.keys(providerPricing)) {
-      if (pattern !== "*" && modelId.toLowerCase().includes(pattern.toLowerCase())) {
-        return false; // Pattern match found
-      }
-    }
-    return true; // Using wildcard
-  } else {
-    const config = getSTTPricingConfig();
-    const providerPricing = config[providerId];
-    if (!providerPricing) return true;
-    if (providerPricing[modelId]) return false;
-    for (const pattern of Object.keys(providerPricing)) {
-      if (pattern !== "*" && modelId.toLowerCase().includes(pattern.toLowerCase())) {
-        return false;
-      }
-    }
-    return true;
-  }
+function CostEstimation({
+  providerId,
+  modelId,
+  type,
+}: {
+  providerId: string;
+  modelId: string;
+  type: "ai" | "stt";
+}) {
+  const { estimatedCost } = usePricing({ providerId, modelId, type });
+
+  if (!estimatedCost) return null;
+
+  return (
+    <div className="text-xs text-muted-foreground mt-1 flex items-center gap-1">
+      <span>Estimated: {estimatedCost.text}</span>
+      {estimatedCost.isEstimate && (
+        <span
+          className="inline-flex items-center gap-0.5 text-yellow-600 dark:text-yellow-500"
+          title="Using estimated pricing - actual cost may vary"
+        >
+          <AlertCircle className="h-3 w-3" />
+          <span className="text-[10px]">(est.)</span>
+        </span>
+      )}
+    </div>
+  );
 }
 
 /**
- * Format pricing for display in dropdown
+ * Custom model input mode
  */
-function formatAIPricing(providerId: string, modelId: string): { text: string; isEstimate: boolean } {
-  const pricing = getModelPricing(providerId, modelId);
-  const isEstimate = isUsingFallbackPricing(providerId, modelId, "ai");
-  if (pricing.inputPer1k === 0 && pricing.outputPer1k === 0) {
-    return { text: "Free", isEstimate: false };
-  }
-  return {
-    text: `$${pricing.inputPer1k}/$${pricing.outputPer1k} per 1K`,
-    isEstimate
-  };
-}
-
-function formatSTTPricing(providerId: string, modelId: string): { text: string; isEstimate: boolean } {
-  const pricing = getSTTModelPricing(providerId, modelId);
-  const isEstimate = isUsingFallbackPricing(providerId, modelId, "stt");
-  if (pricing.perMinute === 0) {
-    return { text: "Free", isEstimate: false };
-  }
-  const text = pricing.perMinute < 0.001
-    ? `$${pricing.perMinute.toFixed(5)}/min`
-    : `$${pricing.perMinute.toFixed(4)}/min`;
-  return { text, isEstimate };
-}
-
-/**
- * Calculate estimated cost for typical usage
- */
-function getEstimatedCost(
-  providerId: string,
-  modelId: string,
-  type: "ai" | "stt"
-): { text: string; isEstimate: boolean } {
-  const isEstimate = isUsingFallbackPricing(providerId, modelId, type);
-
-  if (type === "ai") {
-    const pricing = getModelPricing(providerId, modelId);
-    if (pricing.inputPer1k === 0 && pricing.outputPer1k === 0) {
-      return { text: "Free (local model)", isEstimate: false };
-    }
-    // Estimate based on 500 input + 500 output tokens (typical request)
-    const inputCost = (500 / 1000) * pricing.inputPer1k;
-    const outputCost = (500 / 1000) * pricing.outputPer1k;
-    const totalCost = inputCost + outputCost;
-    return {
-      text: `~${formatCost(totalCost)} per typical request (500 in/out tokens)`,
-      isEstimate
-    };
-  } else {
-    const pricing = getSTTModelPricing(providerId, modelId);
-    if (pricing.perMinute === 0) {
-      return { text: "Free (local model)", isEstimate: false };
-    }
-    return {
-      text: `~${formatCost(pricing.perMinute)} per minute of audio`,
-      isEstimate
-    };
-  }
-}
-
-export const ModelSelector = ({
+function CustomModelInput({
   providerId,
   selectedModel,
   onModelChange,
   type,
   providerDisplayName,
-}: ModelSelectorProps) => {
-  const [isCustomMode, setIsCustomMode] = useState(false);
-
-  const models = useMemo(
-    () =>
-      type === "ai"
-        ? getAIModelsForProvider(providerId)
-        : getSTTModelsForProvider(providerId),
-    [providerId, type]
-  );
-
-  const hasModels = hasModelsForProvider(providerId, type);
-
-  // Check if the current selected model is in the predefined list
-  const isSelectedModelPredefined = useMemo(
-    () => hasModels && models.some((m) => m.id === selectedModel),
-    [hasModels, models, selectedModel]
-  );
-
-  // Sync custom mode state: exit custom mode if user selects a predefined model
-  useEffect(() => {
-    if (isSelectedModelPredefined && isCustomMode) {
-      setIsCustomMode(false);
-    }
-  }, [isSelectedModelPredefined, isCustomMode]);
-
-  // If no predefined models, or we're in custom mode, show text input
-  if (!hasModels || isCustomMode) {
-    const costInfo = selectedModel
-      ? getEstimatedCost(providerId, selectedModel, type)
-      : null;
-
-    return (
-      <div className="space-y-2">
-        <Header
-          title="MODEL"
-          description={`Enter the model identifier for ${
-            providerDisplayName || providerId
-          }`}
-        />
-        <div className="flex gap-2">
-          <Input
-            type="text"
-            placeholder={`Enter model name (e.g., ${
-              type === "ai" ? "gpt-4o" : "whisper-1"
-            })`}
-            value={selectedModel}
-            onChange={(e) => onModelChange(e.target.value)}
-            className="flex-1 h-11 border-1 border-input/50 focus:border-primary/50 transition-colors"
-          />
-          {hasModels && isCustomMode && (
-            <button
-              onClick={() => setIsCustomMode(false)}
-              className="px-3 h-11 text-sm bg-secondary hover:bg-secondary/80 rounded-md transition-colors"
-              title="Back to model list"
-            >
-              List
-            </button>
-          )}
-        </div>
-        {costInfo && (
-          <div className="text-xs text-muted-foreground mt-1 flex items-center gap-1">
-            <span>Estimated: {costInfo.text}</span>
-            {costInfo.isEstimate && (
-              <span className="inline-flex items-center gap-0.5 text-yellow-600 dark:text-yellow-500" title="Using estimated pricing - actual cost may vary">
-                <AlertCircle className="h-3 w-3" />
-                <span className="text-[10px]">(est.)</span>
-              </span>
-            )}
-          </div>
-        )}
-      </div>
-    );
-  }
-
-  // If selected model is not in predefined list but we have models, show as custom
-  const displayValue =
-    !isSelectedModelPredefined && selectedModel
-      ? CUSTOM_MODEL_VALUE
-      : selectedModel;
-
-  // Get the display name for the selected model
-  const getSelectedModelDisplay = () => {
-    if (!selectedModel) return null;
-
-    // If it's a custom model (not in predefined list)
-    if (!isSelectedModelPredefined) {
-      return (
-        <span className="flex items-center gap-2">
-          <Pencil className="h-3 w-3" />
-          {selectedModel}
-        </span>
-      );
-    }
-
-    // Find the model in the predefined list
-    const modelInfo = models.find((m) => m.id === selectedModel);
-    if (modelInfo) {
-      return (
-        <span className="flex items-center gap-2">
-          {modelInfo.recommended && <Star className="h-3 w-3 text-yellow-500" />}
-          {modelInfo.name}
-        </span>
-      );
-    }
-
-    return selectedModel;
-  };
-
-  // Get cost info for the footer
-  const costInfo = selectedModel
-    ? getEstimatedCost(providerId, selectedModel, type)
-    : null;
-
+  hasModels,
+  onBackToList,
+}: {
+  providerId: string;
+  selectedModel: string;
+  onModelChange: (model: string) => void;
+  type: "ai" | "stt";
+  providerDisplayName?: string;
+  hasModels: boolean;
+  onBackToList: () => void;
+}) {
   return (
     <div className="space-y-2">
       <Header
         title="MODEL"
-        description={`Select a model for ${
+        description={`Enter the model identifier for ${
           providerDisplayName || providerId
-        } or enter a custom model name`}
+        }`}
       />
-      <Select
-        value={displayValue || ""}
-        onValueChange={(value) => {
-          if (value === CUSTOM_MODEL_VALUE) {
-            setIsCustomMode(true);
-          } else {
-            onModelChange(value);
-          }
-        }}
-      >
-        <SelectTrigger className="w-full h-11 border-1 border-input/50 focus:border-primary/50 transition-colors">
-          <SelectValue placeholder="Select a model">
-            {getSelectedModelDisplay()}
-          </SelectValue>
-        </SelectTrigger>
-        <SelectContent>
-          {/* Recommended models first */}
-          {models.filter((m) => m.recommended).length > 0 && (
-            <>
-              <div className="px-2 py-1 text-xs font-semibold text-muted-foreground">
-                Recommended
-              </div>
-              {models
-                .filter((m) => m.recommended)
-                .map((model) => (
-                  <ModelSelectItem
-                    key={model.id}
-                    model={model}
-                    providerId={providerId}
-                    type={type}
-                    showStar
-                  />
-                ))}
-            </>
-          )}
-
-          {/* Other models */}
-          {models.filter((m) => !m.recommended).length > 0 && (
-            <>
-              {models.filter((m) => m.recommended).length > 0 && (
-                <div className="border-t border-input/50 my-1" />
-              )}
-              <div className="px-2 py-1 text-xs font-semibold text-muted-foreground">
-                All Models
-              </div>
-              {models
-                .filter((m) => !m.recommended)
-                .map((model) => (
-                  <ModelSelectItem
-                    key={model.id}
-                    model={model}
-                    providerId={providerId}
-                    type={type}
-                  />
-                ))}
-            </>
-          )}
-
-          {/* Custom model option */}
-          <div className="border-t border-input/50 my-1" />
-          <SelectItem
-            value={CUSTOM_MODEL_VALUE}
-            className="cursor-pointer hover:bg-accent/50"
+      <div className="flex gap-2">
+        <Input
+          type="text"
+          placeholder={`Enter model name (e.g., ${
+            type === "ai" ? "gpt-4o" : "whisper-1"
+          })`}
+          value={selectedModel}
+          onChange={(e) => onModelChange(e.target.value)}
+          className="flex-1 h-11 border-1 border-input/50 focus:border-primary/50 transition-colors"
+        />
+        {hasModels && (
+          <button
+            onClick={onBackToList}
+            className="px-3 h-11 text-sm bg-secondary hover:bg-secondary/80 rounded-md transition-colors"
+            title="Back to model list"
           >
-            <span className="flex items-center gap-2">
-              <Pencil className="h-3 w-3" />
-              <span>Custom model...</span>
-            </span>
-          </SelectItem>
-        </SelectContent>
-      </Select>
-
-      {/* Cost estimation */}
-      {costInfo && (
-        <div className="text-xs text-muted-foreground mt-1 flex items-center gap-1">
-          <span>Estimated: {costInfo.text}</span>
-          {costInfo.isEstimate && (
-            <span className="inline-flex items-center gap-0.5 text-yellow-600 dark:text-yellow-500" title="Using estimated pricing - actual cost may vary">
-              <AlertCircle className="h-3 w-3" />
-              <span className="text-[10px]">(est.)</span>
-            </span>
-          )}
-        </div>
+            List
+          </button>
+        )}
+      </div>
+      {selectedModel && (
+        <CostEstimation providerId={providerId} modelId={selectedModel} type={type} />
       )}
     </div>
   );
-};
+}
 
 /**
  * Individual model option in the select dropdown
@@ -385,3 +153,206 @@ function ModelSelectItem({
     </SelectItem>
   );
 }
+
+/**
+ * Section header for model groups
+ */
+function ModelGroupHeader({ title }: { title: string }) {
+  return (
+    <div className="px-2 py-1 text-xs font-semibold text-muted-foreground">
+      {title}
+    </div>
+  );
+}
+
+/**
+ * Divider between model groups
+ */
+function GroupDivider() {
+  return <div className="border-t border-input/50 my-1" />;
+}
+
+/**
+ * Selected model display in the select trigger
+ */
+function SelectedModelDisplay({
+  selectedModel,
+  isSelectedModelPredefined,
+  models,
+}: {
+  selectedModel: string;
+  isSelectedModelPredefined: boolean;
+  models: ModelOption[];
+}) {
+  if (!selectedModel) return null;
+
+  // If it's a custom model (not in predefined list)
+  if (!isSelectedModelPredefined) {
+    return (
+      <span className="flex items-center gap-2">
+        <Pencil className="h-3 w-3" />
+        {selectedModel}
+      </span>
+    );
+  }
+
+  // Find the model in the predefined list
+  const modelInfo = models.find((m) => m.id === selectedModel);
+  if (modelInfo) {
+    return (
+      <span className="flex items-center gap-2">
+        {modelInfo.recommended && <Star className="h-3 w-3 text-yellow-500" />}
+        {modelInfo.name}
+      </span>
+    );
+  }
+
+  return <span>{selectedModel}</span>;
+}
+
+/**
+ * ModelSelector Component
+ *
+ * A dropdown component for selecting AI or STT models with:
+ * - Predefined model lists for known providers
+ * - Custom model input option
+ * - Pricing display per model
+ * - Cost estimation
+ */
+export const ModelSelector = ({
+  providerId,
+  selectedModel,
+  onModelChange,
+  type,
+  providerDisplayName,
+}: ModelSelectorProps) => {
+  const [isCustomMode, setIsCustomMode] = useState(false);
+
+  const models = useMemo(
+    () =>
+      type === "ai"
+        ? getAIModelsForProvider(providerId)
+        : getSTTModelsForProvider(providerId),
+    [providerId, type]
+  );
+
+  const hasModels = hasModelsForProvider(providerId, type);
+
+  // Check if the current selected model is in the predefined list
+  const isSelectedModelPredefined = useMemo(
+    () => hasModels && models.some((m) => m.id === selectedModel),
+    [hasModels, models, selectedModel]
+  );
+
+  // Sync custom mode state: exit custom mode if user selects a predefined model
+  useEffect(() => {
+    if (isSelectedModelPredefined && isCustomMode) {
+      setIsCustomMode(false);
+    }
+  }, [isSelectedModelPredefined, isCustomMode]);
+
+  // If no predefined models, or we're in custom mode, show text input
+  if (!hasModels || isCustomMode) {
+    return (
+      <CustomModelInput
+        providerId={providerId}
+        selectedModel={selectedModel}
+        onModelChange={onModelChange}
+        type={type}
+        providerDisplayName={providerDisplayName}
+        hasModels={hasModels}
+        onBackToList={() => setIsCustomMode(false)}
+      />
+    );
+  }
+
+  // If selected model is not in predefined list but we have models, show as custom
+  const displayValue =
+    !isSelectedModelPredefined && selectedModel
+      ? CUSTOM_MODEL_VALUE
+      : selectedModel;
+
+  const recommendedModels = models.filter((m) => m.recommended);
+  const otherModels = models.filter((m) => !m.recommended);
+
+  return (
+    <div className="space-y-2">
+      <Header
+        title="MODEL"
+        description={`Select a model for ${
+          providerDisplayName || providerId
+        } or enter a custom model name`}
+      />
+      <Select
+        value={displayValue || ""}
+        onValueChange={(value) => {
+          if (value === CUSTOM_MODEL_VALUE) {
+            setIsCustomMode(true);
+          } else {
+            onModelChange(value);
+          }
+        }}
+      >
+        <SelectTrigger className="w-full h-11 border-1 border-input/50 focus:border-primary/50 transition-colors">
+          <SelectValue placeholder="Select a model">
+            <SelectedModelDisplay
+              selectedModel={selectedModel}
+              isSelectedModelPredefined={isSelectedModelPredefined}
+              models={models}
+            />
+          </SelectValue>
+        </SelectTrigger>
+        <SelectContent>
+          {/* Recommended models first */}
+          {recommendedModels.length > 0 && (
+            <>
+              <ModelGroupHeader title="Recommended" />
+              {recommendedModels.map((model) => (
+                <ModelSelectItem
+                  key={model.id}
+                  model={model}
+                  providerId={providerId}
+                  type={type}
+                  showStar
+                />
+              ))}
+            </>
+          )}
+
+          {/* Other models */}
+          {otherModels.length > 0 && (
+            <>
+              {recommendedModels.length > 0 && <GroupDivider />}
+              <ModelGroupHeader title="All Models" />
+              {otherModels.map((model) => (
+                <ModelSelectItem
+                  key={model.id}
+                  model={model}
+                  providerId={providerId}
+                  type={type}
+                />
+              ))}
+            </>
+          )}
+
+          {/* Custom model option */}
+          <GroupDivider />
+          <SelectItem
+            value={CUSTOM_MODEL_VALUE}
+            className="cursor-pointer hover:bg-accent/50"
+          >
+            <span className="flex items-center gap-2">
+              <Pencil className="h-3 w-3" />
+              <span>Custom model...</span>
+            </span>
+          </SelectItem>
+        </SelectContent>
+      </Select>
+
+      {/* Cost estimation */}
+      {selectedModel && (
+        <CostEstimation providerId={providerId} modelId={selectedModel} type={type} />
+      )}
+    </div>
+  );
+};

--- a/src/components/ProviderVerification/index.tsx
+++ b/src/components/ProviderVerification/index.tsx
@@ -53,18 +53,22 @@ export const ProviderVerification = ({
       return;
     }
 
-    const isValid = type === "ai"
-      ? isAIVerificationValid(providerId, model, apiKey)
-      : isSTTVerificationValid(providerId, model, apiKey);
+    const checkVerification = async () => {
+      const isValid = type === "ai"
+        ? await isAIVerificationValid(providerId, model, apiKey)
+        : await isSTTVerificationValid(providerId, model, apiKey);
 
-    if (isValid) {
-      setState("verified");
-      onVerificationChange?.(true);
-    } else {
-      setState("idle");
-      onVerificationChange?.(false);
-    }
-  }, [providerId, model, apiKey, isConfigured, type]);
+      if (isValid) {
+        setState("verified");
+        onVerificationChange?.(true);
+      } else {
+        setState("idle");
+        onVerificationChange?.(false);
+      }
+    };
+
+    checkVerification();
+  }, [providerId, model, apiKey, isConfigured, type, onVerificationChange]);
 
   const handleVerify = useCallback(async () => {
     if (!isConfigured || state === "testing") return;
@@ -91,9 +95,9 @@ export const ProviderVerification = ({
       setState("verified");
       setErrorMessage(null);
       if (type === "ai") {
-        setAIVerificationStatus(providerId, model, apiKey, true);
+        await setAIVerificationStatus(providerId, model, apiKey, true);
       } else {
-        setSTTVerificationStatus(providerId, model, apiKey, true);
+        await setSTTVerificationStatus(providerId, model, apiKey, true);
       }
       // Notify other components that verification status changed
       window.dispatchEvent(new CustomEvent("verification-status-changed"));
@@ -102,9 +106,9 @@ export const ProviderVerification = ({
       setState("failed");
       setErrorMessage(result.error || result.message);
       if (type === "ai") {
-        setAIVerificationStatus(providerId, model, apiKey, false, result.error);
+        await setAIVerificationStatus(providerId, model, apiKey, false, result.error);
       } else {
-        setSTTVerificationStatus(providerId, model, apiKey, false, result.error);
+        await setSTTVerificationStatus(providerId, model, apiKey, false, result.error);
       }
       // Notify other components that verification status changed
       window.dispatchEvent(new CustomEvent("verification-status-changed"));

--- a/src/components/ProviderVerification/index.tsx
+++ b/src/components/ProviderVerification/index.tsx
@@ -1,6 +1,6 @@
-import { useState, useCallback, useEffect } from "react";
+import { useState, useCallback, useEffect, useMemo } from "react";
 import { Checkbox } from "@/components/ui/checkbox";
-import { Loader2, CheckCircle2, XCircle, AlertCircle } from "lucide-react";
+import { Loader2, CheckCircle2, XCircle, AlertCircle, ExternalLink } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { TYPE_PROVIDER } from "@/types";
 import { testAIProvider, testSTTProvider, TestResult } from "@/lib/functions";
@@ -12,6 +12,164 @@ import {
   clearAIVerificationStatus,
   clearSTTVerificationStatus,
 } from "@/lib/storage";
+
+/**
+ * Error categorization for user-friendly messages
+ */
+interface ErrorInfo {
+  /** User-friendly error title */
+  title: string;
+  /** Detailed explanation */
+  description: string;
+  /** Actionable next steps */
+  actions: string[];
+  /** Optional Learn More link */
+  learnMoreUrl?: string;
+}
+
+/**
+ * Provider documentation URLs for common providers
+ */
+const PROVIDER_DOCS: Record<string, { ai?: string; stt?: string }> = {
+  openai: {
+    ai: "https://platform.openai.com/docs/api-reference/authentication",
+    stt: "https://platform.openai.com/docs/api-reference/audio/createTranscription",
+  },
+  claude: {
+    ai: "https://docs.anthropic.com/en/api/getting-started",
+  },
+  groq: {
+    ai: "https://console.groq.com/docs/quickstart",
+    stt: "https://console.groq.com/docs/speech-text",
+  },
+  gemini: {
+    ai: "https://ai.google.dev/gemini-api/docs/api-key",
+  },
+  "deepgram-stt": {
+    stt: "https://developers.deepgram.com/docs/authenticating",
+  },
+  "assemblyai-diarization": {
+    stt: "https://www.assemblyai.com/docs/getting-started",
+  },
+};
+
+/**
+ * Categorize error message and provide actionable guidance
+ */
+function categorizeError(
+  errorMessage: string | null,
+  providerId: string,
+  type: "ai" | "stt"
+): ErrorInfo {
+  const providerDocs = PROVIDER_DOCS[providerId]?.[type];
+
+  // Default error
+  const defaultError: ErrorInfo = {
+    title: "Verification failed",
+    description: errorMessage || "Could not verify the API connection",
+    actions: ["Double-check your API key", "Ensure your account is active"],
+    learnMoreUrl: providerDocs,
+  };
+
+  if (!errorMessage) return defaultError;
+
+  const lowerError = errorMessage.toLowerCase();
+
+  // Authentication errors
+  if (lowerError.includes("invalid api key") ||
+      lowerError.includes("authentication") ||
+      lowerError.includes("401") ||
+      lowerError.includes("403") ||
+      lowerError.includes("unauthorized")) {
+    return {
+      title: "Invalid API key",
+      description: "The API key you entered was rejected by the provider.",
+      actions: [
+        "Verify the API key is copied correctly (no extra spaces)",
+        "Check that the key hasn't expired or been revoked",
+        "Ensure the key has the necessary permissions",
+      ],
+      learnMoreUrl: providerDocs,
+    };
+  }
+
+  // Rate limiting
+  if (lowerError.includes("rate limit") || lowerError.includes("429")) {
+    return {
+      title: "Rate limited",
+      description: "Too many requests. Your API key is valid but you've hit usage limits.",
+      actions: [
+        "Wait a few minutes before trying again",
+        "Check your usage quota in the provider dashboard",
+      ],
+      learnMoreUrl: providerDocs,
+    };
+  }
+
+  // Network errors
+  if (lowerError.includes("network") ||
+      lowerError.includes("timeout") ||
+      lowerError.includes("connection") ||
+      lowerError.includes("fetch failed")) {
+    return {
+      title: "Connection failed",
+      description: "Could not reach the API server.",
+      actions: [
+        "Check your internet connection",
+        "Try again in a few moments",
+        "Verify the provider's service status",
+      ],
+      learnMoreUrl: undefined, // No provider-specific docs needed for network issues
+    };
+  }
+
+  // Configuration errors
+  if (lowerError.includes("configuration") ||
+      lowerError.includes("missing") ||
+      lowerError.includes("required")) {
+    return {
+      title: "Configuration incomplete",
+      description: "Some required settings are missing.",
+      actions: [
+        "Fill in all required fields above",
+        "Ensure the model name is correct",
+      ],
+      learnMoreUrl: providerDocs,
+    };
+  }
+
+  // Unsupported format
+  if (lowerError.includes("not supported") || lowerError.includes("unsupported")) {
+    return {
+      title: "Verification not available",
+      description: "Automatic verification isn't supported for this provider format.",
+      actions: [
+        "You can still use this provider",
+        "Test manually by sending a message",
+      ],
+      learnMoreUrl: providerDocs,
+    };
+  }
+
+  // Response/parsing errors
+  if (lowerError.includes("response") ||
+      lowerError.includes("invalid") ||
+      lowerError.includes("parse") ||
+      lowerError.includes("json")) {
+    return {
+      title: "Unexpected response",
+      description: "The API responded but in an unexpected format.",
+      actions: [
+        "Verify the model name is correct",
+        "Check if the provider API has changed",
+        "Try a different model",
+      ],
+      learnMoreUrl: providerDocs,
+    };
+  }
+
+  return defaultError;
+}
 
 interface ProviderVerificationProps {
   /** The type of provider being verified */
@@ -158,6 +316,18 @@ export const ProviderVerification = ({
   const isChecked = state === "verified";
   const isDisabled = !isConfigured || state === "testing";
 
+  // Categorize error for better user guidance
+  const errorInfo = useMemo(
+    () => state === "failed" ? categorizeError(errorMessage, providerId, type) : null,
+    [state, errorMessage, providerId, type]
+  );
+
+  // Handle opening external links safely
+  const handleLearnMore = useCallback((url: string) => {
+    // Use Tauri's shell open for security
+    window.open(url, "_blank", "noopener,noreferrer");
+  }, []);
+
   return (
     <div className="mt-4 p-3 rounded-lg border border-border bg-muted/30">
       <div className="flex items-start gap-3">
@@ -199,31 +369,58 @@ export const ProviderVerification = ({
           </div>
 
           {/* Description or Error */}
-          <p className={cn(
-            "text-xs mt-0.5",
-            state === "failed" ? "text-red-500" : "text-muted-foreground"
-          )}>
-            {!isConfigured ? (
-              "Configure the provider above first"
-            ) : state === "verified" ? (
-              "Connection verified successfully"
-            ) : state === "failed" ? (
-              errorMessage || "Verification failed. Please check your API key."
-            ) : state === "testing" ? (
-              "Please wait while we test the connection..."
-            ) : (
-              "Check this box to verify your API key works"
-            )}
-          </p>
+          {state === "failed" && errorInfo ? (
+            <div className="mt-1.5">
+              <p className="text-xs font-medium text-red-500">
+                {errorInfo.title}
+              </p>
+              <p className="text-xs text-red-400 mt-0.5">
+                {errorInfo.description}
+              </p>
 
-          {/* Retry button for failed state */}
-          {state === "failed" && (
-            <button
-              onClick={() => handleVerify()}
-              className="text-xs text-primary hover:underline mt-1"
-            >
-              Try again
-            </button>
+              {/* Actionable next steps */}
+              {errorInfo.actions.length > 0 && (
+                <ul className="text-xs text-muted-foreground mt-1.5 space-y-0.5 list-disc list-inside">
+                  {errorInfo.actions.map((action, index) => (
+                    <li key={index}>{action}</li>
+                  ))}
+                </ul>
+              )}
+
+              {/* Action buttons */}
+              <div className="flex items-center gap-3 mt-2">
+                <button
+                  onClick={() => handleVerify()}
+                  className="text-xs text-primary hover:underline"
+                >
+                  Try again
+                </button>
+                {errorInfo.learnMoreUrl && (
+                  <button
+                    onClick={() => handleLearnMore(errorInfo.learnMoreUrl!)}
+                    className="text-xs text-muted-foreground hover:text-foreground inline-flex items-center gap-1"
+                  >
+                    Learn more
+                    <ExternalLink className="h-3 w-3" />
+                  </button>
+                )}
+              </div>
+            </div>
+          ) : (
+            <p className={cn(
+              "text-xs mt-0.5",
+              "text-muted-foreground"
+            )}>
+              {!isConfigured ? (
+                "Configure the provider above first"
+              ) : state === "verified" ? (
+                "Connection verified successfully"
+              ) : state === "testing" ? (
+                "Please wait while we test the connection..."
+              ) : (
+                "Check this box to verify your API key works"
+              )}
+            </p>
           )}
         </div>
 

--- a/src/components/ProviderVerification/index.tsx
+++ b/src/components/ProviderVerification/index.tsx
@@ -1,0 +1,214 @@
+import { useState, useCallback, useEffect } from "react";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Loader2, CheckCircle2, XCircle, AlertCircle } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { TYPE_PROVIDER } from "@/types";
+import { testAIProvider, testSTTProvider, TestResult } from "@/lib/functions";
+import {
+  setAIVerificationStatus,
+  setSTTVerificationStatus,
+  isAIVerificationValid,
+  isSTTVerificationValid,
+  clearAIVerificationStatus,
+  clearSTTVerificationStatus,
+} from "@/lib/storage";
+
+interface ProviderVerificationProps {
+  /** The type of provider being verified */
+  type: "ai" | "stt";
+  /** The provider configuration */
+  provider: TYPE_PROVIDER | undefined;
+  /** The selected provider with variables */
+  selectedProvider: {
+    provider: string;
+    variables: Record<string, string>;
+  };
+  /** Whether the provider has the required configuration (API key etc) */
+  isConfigured: boolean;
+  /** Callback when verification status changes */
+  onVerificationChange?: (verified: boolean) => void;
+}
+
+type VerificationState = "idle" | "testing" | "verified" | "failed";
+
+export const ProviderVerification = ({
+  type,
+  provider,
+  selectedProvider,
+  isConfigured,
+  onVerificationChange,
+}: ProviderVerificationProps) => {
+  const [state, setState] = useState<VerificationState>("idle");
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const apiKey = selectedProvider?.variables?.api_key || "";
+  const model = selectedProvider?.variables?.model || "";
+  const providerId = selectedProvider?.provider || "";
+
+  // Check if already verified on mount or when config changes
+  useEffect(() => {
+    if (!isConfigured) {
+      setState("idle");
+      setErrorMessage(null);
+      return;
+    }
+
+    const isValid = type === "ai"
+      ? isAIVerificationValid(providerId, model, apiKey)
+      : isSTTVerificationValid(providerId, model, apiKey);
+
+    if (isValid) {
+      setState("verified");
+      onVerificationChange?.(true);
+    } else {
+      setState("idle");
+      onVerificationChange?.(false);
+    }
+  }, [providerId, model, apiKey, isConfigured, type]);
+
+  const handleVerify = useCallback(async () => {
+    if (!isConfigured || state === "testing") return;
+
+    setState("testing");
+    setErrorMessage(null);
+
+    let result: TestResult;
+    try {
+      if (type === "ai") {
+        result = await testAIProvider(provider, selectedProvider);
+      } else {
+        result = await testSTTProvider(provider, selectedProvider);
+      }
+    } catch (error) {
+      result = {
+        success: false,
+        message: "Test failed",
+        error: error instanceof Error ? error.message : "Unknown error",
+      };
+    }
+
+    if (result.success) {
+      setState("verified");
+      setErrorMessage(null);
+      if (type === "ai") {
+        setAIVerificationStatus(providerId, model, apiKey, true);
+      } else {
+        setSTTVerificationStatus(providerId, model, apiKey, true);
+      }
+      // Notify other components that verification status changed
+      window.dispatchEvent(new CustomEvent("verification-status-changed"));
+      onVerificationChange?.(true);
+    } else {
+      setState("failed");
+      setErrorMessage(result.error || result.message);
+      if (type === "ai") {
+        setAIVerificationStatus(providerId, model, apiKey, false, result.error);
+      } else {
+        setSTTVerificationStatus(providerId, model, apiKey, false, result.error);
+      }
+      // Notify other components that verification status changed
+      window.dispatchEvent(new CustomEvent("verification-status-changed"));
+      onVerificationChange?.(false);
+    }
+  }, [isConfigured, state, type, provider, selectedProvider, providerId, model, apiKey, onVerificationChange]);
+
+  const handleCheckboxChange = useCallback((checked: boolean | "indeterminate") => {
+    if (checked === true) {
+      handleVerify();
+    } else {
+      // Clear verification when unchecked
+      setState("idle");
+      setErrorMessage(null);
+      if (type === "ai") {
+        clearAIVerificationStatus();
+      } else {
+        clearSTTVerificationStatus();
+      }
+      // Notify other components that verification status changed
+      window.dispatchEvent(new CustomEvent("verification-status-changed"));
+      onVerificationChange?.(false);
+    }
+  }, [handleVerify, type, onVerificationChange]);
+
+  const isChecked = state === "verified";
+  const isDisabled = !isConfigured || state === "testing";
+
+  return (
+    <div className="mt-4 p-3 rounded-lg border border-border bg-muted/30">
+      <div className="flex items-start gap-3">
+        {/* Checkbox or Loading Indicator */}
+        <div className="flex items-center justify-center h-5 w-5 mt-0.5">
+          {state === "testing" ? (
+            <Loader2 className="h-4 w-4 animate-spin text-primary" />
+          ) : (
+            <Checkbox
+              checked={isChecked}
+              onCheckedChange={handleCheckboxChange}
+              disabled={isDisabled}
+              className={cn(
+                state === "verified" && "border-green-500 bg-green-500 data-[state=checked]:bg-green-500",
+                state === "failed" && "border-red-500"
+              )}
+            />
+          )}
+        </div>
+
+        {/* Label and Status */}
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2">
+            <span className={cn(
+              "text-sm font-medium",
+              !isConfigured && "text-muted-foreground"
+            )}>
+              {state === "testing"
+                ? `Testing ${type === "ai" ? "AI" : "Speech-to-Text"} connection...`
+                : `Verify ${type === "ai" ? "AI" : "Speech-to-Text"} connection`
+              }
+            </span>
+            {state === "verified" && (
+              <CheckCircle2 className="h-4 w-4 text-green-500" />
+            )}
+            {state === "failed" && (
+              <XCircle className="h-4 w-4 text-red-500" />
+            )}
+          </div>
+
+          {/* Description or Error */}
+          <p className={cn(
+            "text-xs mt-0.5",
+            state === "failed" ? "text-red-500" : "text-muted-foreground"
+          )}>
+            {!isConfigured ? (
+              "Configure the provider above first"
+            ) : state === "verified" ? (
+              "Connection verified successfully"
+            ) : state === "failed" ? (
+              errorMessage || "Verification failed. Please check your API key."
+            ) : state === "testing" ? (
+              "Please wait while we test the connection..."
+            ) : (
+              "Check this box to verify your API key works"
+            )}
+          </p>
+
+          {/* Retry button for failed state */}
+          {state === "failed" && (
+            <button
+              onClick={() => handleVerify()}
+              className="text-xs text-primary hover:underline mt-1"
+            >
+              Try again
+            </button>
+          )}
+        </div>
+
+        {/* Warning icon if not configured */}
+        {!isConfigured && (
+          <AlertCircle className="h-4 w-4 text-muted-foreground flex-shrink-0" />
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default ProviderVerification;

--- a/src/components/ProviderVerification/index.tsx
+++ b/src/components/ProviderVerification/index.tsx
@@ -116,7 +116,7 @@ export const ProviderVerification = ({
     }
   }, [isConfigured, state, type, provider, selectedProvider, providerId, model, apiKey, onVerificationChange]);
 
-  const handleCheckboxChange = useCallback((checked: boolean | "indeterminate") => {
+  const handleCheckboxChange = useCallback(async (checked: boolean | "indeterminate") => {
     if (checked === true) {
       handleVerify();
     } else {
@@ -124,9 +124,9 @@ export const ProviderVerification = ({
       setState("idle");
       setErrorMessage(null);
       if (type === "ai") {
-        clearAIVerificationStatus();
+        await clearAIVerificationStatus();
       } else {
-        clearSTTVerificationStatus();
+        await clearSTTVerificationStatus();
       }
       // Notify other components that verification status changed
       window.dispatchEvent(new CustomEvent("verification-status-changed"));

--- a/src/components/ProviderVerification/index.tsx
+++ b/src/components/ProviderVerification/index.tsx
@@ -264,12 +264,13 @@ export const ProviderVerification = ({
         } else {
           await setSTTVerificationStatus(providerId, model, apiKey, true);
         }
+        // Notify after successful storage to avoid stale reads
+        window.dispatchEvent(new CustomEvent("verification-status-changed"));
       } catch (error) {
         console.error("[ProviderVerification] Error saving verification status:", error);
-        // Continue anyway - verification succeeded even if save failed
+        // Still notify on error - UI state changed even if save failed
+        window.dispatchEvent(new CustomEvent("verification-status-changed"));
       }
-      // Notify other components that verification status changed
-      window.dispatchEvent(new CustomEvent("verification-status-changed"));
       onVerificationChange?.(true);
     } else {
       setState("failed");
@@ -280,12 +281,13 @@ export const ProviderVerification = ({
         } else {
           await setSTTVerificationStatus(providerId, model, apiKey, false, result.error);
         }
+        // Notify after successful storage to avoid stale reads
+        window.dispatchEvent(new CustomEvent("verification-status-changed"));
       } catch (error) {
         console.error("[ProviderVerification] Error saving verification status:", error);
-        // Continue anyway - we still want to show the failed state
+        // Still notify on error - UI state changed even if save failed
+        window.dispatchEvent(new CustomEvent("verification-status-changed"));
       }
-      // Notify other components that verification status changed
-      window.dispatchEvent(new CustomEvent("verification-status-changed"));
       onVerificationChange?.(false);
     }
   }, [isConfigured, state, type, provider, selectedProvider, providerId, model, apiKey, onVerificationChange]);
@@ -303,12 +305,13 @@ export const ProviderVerification = ({
         } else {
           await clearSTTVerificationStatus();
         }
+        // Notify after successful storage to avoid stale reads
+        window.dispatchEvent(new CustomEvent("verification-status-changed"));
       } catch (error) {
         console.error("[ProviderVerification] Error clearing verification status:", error);
-        // Continue anyway - UI state is already updated
+        // Still notify on error - UI state changed even if clear failed
+        window.dispatchEvent(new CustomEvent("verification-status-changed"));
       }
-      // Notify other components that verification status changed
-      window.dispatchEvent(new CustomEvent("verification-status-changed"));
       onVerificationChange?.(false);
     }
   }, [handleVerify, type, onVerificationChange]);

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -3,6 +3,7 @@ import { cn } from "@/lib/utils";
 import { useLocation, useNavigate } from "react-router-dom";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import { useMenuItems, useVersion } from "@/hooks";
+import { AlertCircle } from "lucide-react";
 
 export const Sidebar = () => {
   const { version, isLoading } = useVersion();
@@ -34,11 +35,15 @@ export const Sidebar = () => {
       <nav className="flex-1 space-y-1 px-3 py-6">
         {menu.map((item, index) => (
           <button
-            onClick={() => navigate(item.href)}
+            onClick={() => !item.disabled && navigate(item.href)}
             key={`${item.label}-${index}`}
+            disabled={item.disabled}
             className={cn(
-              "flex w-full items-center justify-between gap-3 rounded-xl px-3 py-2 text-xs lg:text-sm text-sidebar-foreground/70 transition-all duration-300 hover:bg-sidebar-accent hover:text-sidebar-accent-foreground",
-              activeRoute.includes(item.href)
+              "flex w-full items-center justify-between gap-3 rounded-xl px-3 py-2 text-xs lg:text-sm transition-all duration-300",
+              item.disabled
+                ? "text-sidebar-foreground/30 cursor-not-allowed"
+                : "text-sidebar-foreground/70 hover:bg-sidebar-accent hover:text-sidebar-accent-foreground",
+              activeRoute.includes(item.href) && !item.disabled
                 ? "font-medium bg-sidebar-accent text-sidebar-accent-foreground"
                 : ""
             )}
@@ -47,7 +52,9 @@ export const Sidebar = () => {
               <item.icon className="size-3 lg:size-4 transition-all duration-300" />
               {item.label}
             </div>
-            {item.count ? (
+            {item.showWarning ? (
+              <AlertCircle className="size-4 text-yellow-500 animate-pulse" />
+            ) : item.count ? (
               <span className="flex size-5 items-center justify-center rounded-md bg-muted text-xs font-semibold text-muted-foreground">
                 {item.count}
               </span>

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -14,3 +14,4 @@ export * from "./Icons";
 export * from "./SpeakerTaggingPopover";
 export * from "./WingIcon";
 export * from "./ModelSelector";
+export * from "./ProviderVerification";

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -13,3 +13,4 @@ export * from "./Markdown/copy-button";
 export * from "./Icons";
 export * from "./SpeakerTaggingPopover";
 export * from "./WingIcon";
+export * from "./ModelSelector";

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -47,6 +47,14 @@ export const STORAGE_KEYS = {
 
   // User Identity settings
   USER_IDENTITY: "user_identity",
+
+  // API Verification status
+  AI_PROVIDER_VERIFIED: "ai_provider_verified",
+  STT_PROVIDER_VERIFIED: "stt_provider_verified",
+
+  // Per-provider configuration storage (remembers API keys when switching providers)
+  AI_PROVIDER_CONFIGS: "ai_provider_configs",
+  STT_PROVIDER_CONFIGS: "stt_provider_configs",
 } as const;
 
 // Max number of files that can be attached to a message

--- a/src/config/models.constants.ts
+++ b/src/config/models.constants.ts
@@ -175,8 +175,7 @@ export const AI_MODELS: Record<string, ModelOption[]> = {
     { id: "gpt-3.5-turbo", name: "GPT-3.5 Turbo", description: "Fast, cost-effective" },
   ],
   claude: [
-    { id: "claude-sonnet-4-20250514", name: "Claude Sonnet 4", recommended: true, description: "Latest and most capable" },
-    { id: "claude-3-5-sonnet-20241022", name: "Claude 3.5 Sonnet", description: "Excellent balance of speed and quality" },
+    { id: "claude-3-5-sonnet-20241022", name: "Claude 3.5 Sonnet", recommended: true, description: "Latest, excellent balance of speed and quality" },
     { id: "claude-3-opus-20240229", name: "Claude 3 Opus", description: "Highest capability" },
     { id: "claude-3-sonnet-20240229", name: "Claude 3 Sonnet", description: "Good balance" },
     { id: "claude-3-haiku-20240307", name: "Claude 3 Haiku", description: "Fastest, most affordable" },

--- a/src/config/models.constants.ts
+++ b/src/config/models.constants.ts
@@ -306,3 +306,94 @@ export function hasModelsForProvider(providerId: string, type: "ai" | "stt"): bo
   }
   return providerId in STT_MODELS && STT_MODELS[providerId].length > 0;
 }
+
+/**
+ * Check if a model exists in the predefined list for a provider.
+ * Returns true if:
+ * - The model is in the predefined list, OR
+ * - The provider has no predefined models (custom models allowed)
+ *
+ * @param providerId - The provider ID
+ * @param modelId - The model ID to validate
+ * @param type - "ai" or "stt"
+ * @returns true if the model is valid for this provider
+ */
+export function isModelValidForProvider(
+  providerId: string,
+  modelId: string,
+  type: "ai" | "stt"
+): boolean {
+  // Empty model is invalid
+  if (!modelId || modelId.trim() === "") {
+    return false;
+  }
+
+  const models = type === "ai"
+    ? getAIModelsForProvider(providerId)
+    : getSTTModelsForProvider(providerId);
+
+  // If no predefined models, any model is valid (custom provider)
+  if (models.length === 0) {
+    return true;
+  }
+
+  // Check if model exists in predefined list
+  return models.some((m) => m.id === modelId);
+}
+
+/**
+ * Validate model configuration for a provider.
+ * Returns an error message if invalid, null if valid.
+ *
+ * @param providerId - The provider ID
+ * @param modelId - The model ID to validate
+ * @param type - "ai" or "stt"
+ * @returns Error message or null if valid
+ */
+export function validateModelForProvider(
+  providerId: string,
+  modelId: string,
+  type: "ai" | "stt"
+): string | null {
+  if (!modelId || modelId.trim() === "") {
+    return "Model is required";
+  }
+
+  // Custom models are always allowed
+  const models = type === "ai"
+    ? getAIModelsForProvider(providerId)
+    : getSTTModelsForProvider(providerId);
+
+  // No predefined models = custom provider, any model valid
+  if (models.length === 0) {
+    return null;
+  }
+
+  // Check if it's a known model
+  const isKnown = models.some((m) => m.id === modelId);
+
+  // For providers with predefined models, we still allow custom models
+  // but we can return a warning (not an error)
+  if (!isKnown) {
+    // This is informational, not a blocking error
+    // Custom models are allowed but not in the predefined list
+    return null; // Allow custom models
+  }
+
+  return null;
+}
+
+/**
+ * Get the recommended model for a provider.
+ * Returns null if no models are defined or no recommended model.
+ */
+export function getRecommendedModel(
+  providerId: string,
+  type: "ai" | "stt"
+): ModelOption | null {
+  const models = type === "ai"
+    ? getAIModelsForProvider(providerId)
+    : getSTTModelsForProvider(providerId);
+
+  return models.find((m) => m.recommended) || models[0] || null;
+}

--- a/src/config/models.constants.ts
+++ b/src/config/models.constants.ts
@@ -1,0 +1,309 @@
+/**
+ * Model configurations for AI and STT providers.
+ * Used to populate model dropdowns in the Dev Space settings.
+ */
+
+export interface ModelOption {
+  id: string;
+  name: string;
+  recommended?: boolean;
+  description?: string;
+}
+
+export interface ProviderInfo {
+  name: string;
+  signupUrl: string;
+  pricingUrl?: string;
+  description: string;
+}
+
+/**
+ * AI provider information including signup and pricing URLs.
+ */
+export const AI_PROVIDER_INFO: Record<string, ProviderInfo> = {
+  openai: {
+    name: "OpenAI",
+    signupUrl: "https://platform.openai.com/signup",
+    pricingUrl: "https://openai.com/api/pricing",
+    description: "Get your API key and credits from OpenAI",
+  },
+  claude: {
+    name: "Anthropic",
+    signupUrl: "https://console.anthropic.com/",
+    pricingUrl: "https://www.anthropic.com/pricing#anthropic-api",
+    description: "Get your API key and credits from Anthropic",
+  },
+  grok: {
+    name: "xAI",
+    signupUrl: "https://console.x.ai/",
+    pricingUrl: "https://x.ai/api",
+    description: "Get your API key from xAI",
+  },
+  gemini: {
+    name: "Google AI Studio",
+    signupUrl: "https://aistudio.google.com/apikey",
+    pricingUrl: "https://ai.google.dev/pricing",
+    description: "Get your API key from Google AI Studio",
+  },
+  mistral: {
+    name: "Mistral AI",
+    signupUrl: "https://console.mistral.ai/",
+    pricingUrl: "https://mistral.ai/technology/#pricing",
+    description: "Get your API key and credits from Mistral AI",
+  },
+  cohere: {
+    name: "Cohere",
+    signupUrl: "https://dashboard.cohere.com/welcome/register",
+    pricingUrl: "https://cohere.com/pricing",
+    description: "Get your API key and credits from Cohere",
+  },
+  groq: {
+    name: "Groq",
+    signupUrl: "https://console.groq.com/keys",
+    pricingUrl: "https://groq.com/pricing/",
+    description: "Get your API key from Groq (generous free tier!)",
+  },
+  perplexity: {
+    name: "Perplexity",
+    signupUrl: "https://www.perplexity.ai/settings/api",
+    pricingUrl: "https://docs.perplexity.ai/guides/pricing",
+    description: "Get your API key and credits from Perplexity",
+  },
+  openrouter: {
+    name: "OpenRouter",
+    signupUrl: "https://openrouter.ai/keys",
+    pricingUrl: "https://openrouter.ai/models",
+    description: "Access multiple AI providers through one API",
+  },
+  ollama: {
+    name: "Ollama",
+    signupUrl: "https://ollama.com/download",
+    description: "Download and run models locally for free",
+  },
+};
+
+/**
+ * STT provider information including signup and pricing URLs.
+ */
+export const STT_PROVIDER_INFO: Record<string, ProviderInfo> = {
+  "openai-whisper": {
+    name: "OpenAI Whisper",
+    signupUrl: "https://platform.openai.com/signup",
+    pricingUrl: "https://openai.com/api/pricing",
+    description: "Get your API key from OpenAI",
+  },
+  groq: {
+    name: "Groq Whisper",
+    signupUrl: "https://console.groq.com/keys",
+    pricingUrl: "https://groq.com/pricing/",
+    description: "Get your API key from Groq (very affordable!)",
+  },
+  "elevenlabs-stt": {
+    name: "ElevenLabs",
+    signupUrl: "https://elevenlabs.io/app/sign-up",
+    pricingUrl: "https://elevenlabs.io/pricing",
+    description: "Get your API key from ElevenLabs",
+  },
+  "google-stt": {
+    name: "Google Cloud Speech",
+    signupUrl: "https://console.cloud.google.com/apis/credentials",
+    pricingUrl: "https://cloud.google.com/speech-to-text/pricing",
+    description: "Get your API key from Google Cloud Console",
+  },
+  "deepgram-stt": {
+    name: "Deepgram",
+    signupUrl: "https://console.deepgram.com/signup",
+    pricingUrl: "https://deepgram.com/pricing",
+    description: "Get your API key from Deepgram",
+  },
+  "azure-stt": {
+    name: "Azure Speech Services",
+    signupUrl: "https://azure.microsoft.com/en-us/products/ai-services/speech-to-text",
+    pricingUrl: "https://azure.microsoft.com/en-us/pricing/details/cognitive-services/speech-services/",
+    description: "Get your API key from Azure Portal",
+  },
+  "speechmatics-stt": {
+    name: "Speechmatics",
+    signupUrl: "https://portal.speechmatics.com/signup",
+    pricingUrl: "https://www.speechmatics.com/pricing",
+    description: "Get your API key from Speechmatics",
+  },
+  "rev-ai-stt": {
+    name: "Rev.ai",
+    signupUrl: "https://www.rev.ai/auth/signup",
+    pricingUrl: "https://www.rev.ai/pricing",
+    description: "Get your API key from Rev.ai",
+  },
+  "ibm-watson-stt": {
+    name: "IBM Watson",
+    signupUrl: "https://cloud.ibm.com/catalog/services/speech-to-text",
+    pricingUrl: "https://www.ibm.com/products/speech-to-text/pricing",
+    description: "Get your API key from IBM Cloud",
+  },
+  "assemblyai-diarization": {
+    name: "AssemblyAI",
+    signupUrl: "https://www.assemblyai.com/app/signup",
+    pricingUrl: "https://www.assemblyai.com/pricing",
+    description: "Get your API key from AssemblyAI",
+  },
+};
+
+/**
+ * Get provider info for an AI provider.
+ */
+export function getAIProviderInfo(providerId: string): ProviderInfo | null {
+  return AI_PROVIDER_INFO[providerId] || null;
+}
+
+/**
+ * Get provider info for an STT provider.
+ */
+export function getSTTProviderInfo(providerId: string): ProviderInfo | null {
+  return STT_PROVIDER_INFO[providerId] || null;
+}
+
+/**
+ * AI model options per provider.
+ * Models are ordered by recommendation/popularity.
+ */
+export const AI_MODELS: Record<string, ModelOption[]> = {
+  openai: [
+    { id: "gpt-4o", name: "GPT-4 Omni", recommended: true, description: "Most capable, multimodal" },
+    { id: "gpt-4o-mini", name: "GPT-4 Omni Mini", description: "Fast and affordable" },
+    { id: "gpt-4-turbo", name: "GPT-4 Turbo", description: "High capability, faster than GPT-4" },
+    { id: "gpt-4", name: "GPT-4", description: "Original GPT-4" },
+    { id: "gpt-3.5-turbo", name: "GPT-3.5 Turbo", description: "Fast, cost-effective" },
+  ],
+  claude: [
+    { id: "claude-sonnet-4-20250514", name: "Claude Sonnet 4", recommended: true, description: "Latest and most capable" },
+    { id: "claude-3-5-sonnet-20241022", name: "Claude 3.5 Sonnet", description: "Excellent balance of speed and quality" },
+    { id: "claude-3-opus-20240229", name: "Claude 3 Opus", description: "Highest capability" },
+    { id: "claude-3-sonnet-20240229", name: "Claude 3 Sonnet", description: "Good balance" },
+    { id: "claude-3-haiku-20240307", name: "Claude 3 Haiku", description: "Fastest, most affordable" },
+  ],
+  grok: [
+    { id: "grok-2", name: "Grok 2", recommended: true, description: "Most capable xAI model" },
+    { id: "grok-2-mini", name: "Grok 2 Mini", description: "Fast and affordable" },
+    { id: "grok-beta", name: "Grok Beta", description: "Beta version" },
+  ],
+  gemini: [
+    { id: "gemini-1.5-pro", name: "Gemini 1.5 Pro", recommended: true, description: "Best quality, long context" },
+    { id: "gemini-1.5-flash", name: "Gemini 1.5 Flash", description: "Fast and affordable" },
+    { id: "gemini-pro", name: "Gemini Pro", description: "Standard Gemini model" },
+  ],
+  mistral: [
+    { id: "mistral-large-latest", name: "Mistral Large", recommended: true, description: "Most capable" },
+    { id: "mistral-medium-latest", name: "Mistral Medium", description: "Balanced performance" },
+    { id: "mistral-small-latest", name: "Mistral Small", description: "Fast and efficient" },
+    { id: "open-mixtral-8x22b", name: "Mixtral 8x22B", description: "Open-source MoE model" },
+    { id: "open-mixtral-8x7b", name: "Mixtral 8x7B", description: "Open-source MoE model" },
+  ],
+  cohere: [
+    { id: "command-r-plus", name: "Command R+", recommended: true, description: "Most capable" },
+    { id: "command-r", name: "Command R", description: "Balanced performance" },
+  ],
+  groq: [
+    { id: "llama-3.3-70b-versatile", name: "Llama 3.3 70B", recommended: true, description: "Latest Llama, versatile" },
+    { id: "llama-3.3-70b-specdec", name: "Llama 3.3 70B SpecDec", description: "Speculative decoding" },
+    { id: "llama-3.1-70b-versatile", name: "Llama 3.1 70B", description: "Large, capable model" },
+    { id: "llama-3.1-8b-instant", name: "Llama 3.1 8B", description: "Fast, efficient" },
+    { id: "llama-3.2-90b-vision-preview", name: "Llama 3.2 90B Vision", description: "Multimodal" },
+    { id: "llama-3.2-11b-vision-preview", name: "Llama 3.2 11B Vision", description: "Multimodal, efficient" },
+    { id: "mixtral-8x7b-32768", name: "Mixtral 8x7B", description: "Open-source MoE" },
+    { id: "gemma2-9b-it", name: "Gemma 2 9B", description: "Google's open model" },
+  ],
+  perplexity: [
+    { id: "llama-3.1-sonar-large-128k-online", name: "Sonar Large", recommended: true, description: "Best quality with web search" },
+    { id: "llama-3.1-sonar-small-128k-online", name: "Sonar Small", description: "Fast with web search" },
+    { id: "llama-3.1-sonar-large-128k-chat", name: "Sonar Large Chat", description: "No web search" },
+    { id: "llama-3.1-sonar-small-128k-chat", name: "Sonar Small Chat", description: "Fast, no web search" },
+  ],
+  openrouter: [
+    { id: "openai/gpt-4o", name: "OpenAI GPT-4o", recommended: true, description: "Via OpenRouter" },
+    { id: "anthropic/claude-3.5-sonnet", name: "Claude 3.5 Sonnet", description: "Via OpenRouter" },
+    { id: "meta-llama/llama-3.1-70b-instruct", name: "Llama 3.1 70B", description: "Via OpenRouter" },
+    { id: "google/gemini-pro-1.5", name: "Gemini 1.5 Pro", description: "Via OpenRouter" },
+    { id: "mistralai/mistral-large", name: "Mistral Large", description: "Via OpenRouter" },
+  ],
+  ollama: [
+    { id: "llama3.2", name: "Llama 3.2", recommended: true, description: "Latest Llama" },
+    { id: "llama3.1", name: "Llama 3.1", description: "Popular choice" },
+    { id: "mistral", name: "Mistral", description: "Fast and capable" },
+    { id: "codellama", name: "Code Llama", description: "Optimized for code" },
+    { id: "phi3", name: "Phi-3", description: "Microsoft small model" },
+    { id: "gemma2", name: "Gemma 2", description: "Google's open model" },
+  ],
+};
+
+/**
+ * STT model options per provider.
+ * Models are ordered by recommendation/popularity.
+ */
+export const STT_MODELS: Record<string, ModelOption[]> = {
+  "openai-whisper": [
+    { id: "whisper-1", name: "Whisper V1", recommended: true, description: "Standard Whisper model" },
+    { id: "gpt-4o-transcribe", name: "GPT-4o Transcribe", description: "High accuracy transcription" },
+    { id: "gpt-4o-mini-transcribe", name: "GPT-4o Mini Transcribe", description: "Fast and affordable" },
+  ],
+  groq: [
+    { id: "whisper-large-v3", name: "Whisper Large V3", recommended: true, description: "Best accuracy" },
+    { id: "whisper-large-v3-turbo", name: "Whisper Large V3 Turbo", description: "Faster variant" },
+    { id: "distil-whisper-large-v3-en", name: "Distil Whisper (English)", description: "Fast, English only" },
+  ],
+  "elevenlabs-stt": [
+    { id: "scribe_v1", name: "Scribe V1", recommended: true, description: "ElevenLabs STT model" },
+  ],
+  "google-stt": [
+    { id: "default", name: "Default", recommended: true, description: "Google Cloud STT" },
+    { id: "latest_long", name: "Latest Long", description: "Optimized for long audio" },
+    { id: "latest_short", name: "Latest Short", description: "Optimized for short audio" },
+  ],
+  "deepgram-stt": [
+    { id: "nova-2", name: "Nova 2", recommended: true, description: "Latest, most accurate" },
+    { id: "nova", name: "Nova", description: "Previous generation" },
+    { id: "enhanced", name: "Enhanced", description: "Higher accuracy" },
+    { id: "base", name: "Base", description: "Standard accuracy" },
+  ],
+  "azure-stt": [
+    { id: "default", name: "Default", recommended: true, description: "Azure Speech Services" },
+  ],
+  "speechmatics-stt": [
+    { id: "default", name: "Default", recommended: true, description: "Speechmatics STT" },
+  ],
+  "rev-ai-stt": [
+    { id: "default", name: "Default", recommended: true, description: "Rev.ai STT" },
+  ],
+  "ibm-watson-stt": [
+    { id: "default", name: "Default", recommended: true, description: "IBM Watson STT" },
+  ],
+  "assemblyai-diarization": [
+    { id: "best", name: "Best", recommended: true, description: "Highest accuracy" },
+    { id: "nano", name: "Nano", description: "Fastest, lower cost" },
+  ],
+};
+
+/**
+ * Get models for a specific AI provider.
+ * Returns empty array if provider not found.
+ */
+export function getAIModelsForProvider(providerId: string): ModelOption[] {
+  return AI_MODELS[providerId] || [];
+}
+
+/**
+ * Get models for a specific STT provider.
+ * Returns empty array if provider not found.
+ */
+export function getSTTModelsForProvider(providerId: string): ModelOption[] {
+  return STT_MODELS[providerId] || [];
+}
+
+/**
+ * Check if a provider has predefined models.
+ */
+export function hasModelsForProvider(providerId: string, type: "ai" | "stt"): boolean {
+  if (type === "ai") {
+    return providerId in AI_MODELS && AI_MODELS[providerId].length > 0;
+  }
+  return providerId in STT_MODELS && STT_MODELS[providerId].length > 0;
+}

--- a/src/contexts/app.context.tsx
+++ b/src/contexts/app.context.tsx
@@ -508,11 +508,40 @@ export const AppProvider = ({ children }: { children: ReactNode }) => {
       return;
     }
 
-    setSelectedAIProvider((prev) => ({
-      ...prev,
-      provider,
-      variables,
-    }));
+    setSelectedAIProvider((prev) => {
+      // If provider is changing, save the old provider's config and load any saved config for the new provider
+      if (provider !== prev.provider) {
+        // Save current provider's variables to per-provider storage (if we have a provider selected)
+        if (prev.provider && Object.keys(prev.variables).length > 0) {
+          const savedConfigs = JSON.parse(safeLocalStorage.getItem(STORAGE_KEYS.AI_PROVIDER_CONFIGS) || '{}');
+          savedConfigs[prev.provider] = prev.variables;
+          safeLocalStorage.setItem(STORAGE_KEYS.AI_PROVIDER_CONFIGS, JSON.stringify(savedConfigs));
+        }
+
+        // Load saved config for the new provider (if any)
+        const savedConfigs = JSON.parse(safeLocalStorage.getItem(STORAGE_KEYS.AI_PROVIDER_CONFIGS) || '{}');
+        const savedVariables = savedConfigs[provider] || {};
+
+        // Merge: saved config as base, then overlay with any passed variables
+        return {
+          provider,
+          variables: {
+            ...savedVariables,
+            ...variables,
+          }
+        };
+      }
+      // If provider is the same, merge variables to prevent stale closure issues
+      // This ensures that updating one variable (e.g., model) doesn't wipe out
+      // another variable (e.g., api_key) due to stale closure captures
+      return {
+        provider,
+        variables: {
+          ...prev.variables,
+          ...variables,
+        },
+      };
+    });
   };
 
   // Setter for selected STT with validation
@@ -528,7 +557,40 @@ export const AppProvider = ({ children }: { children: ReactNode }) => {
       return;
     }
 
-    setSelectedSttProvider((prev) => ({ ...prev, provider, variables }));
+    setSelectedSttProvider((prev) => {
+      // If provider is changing, save the old provider's config and load any saved config for the new provider
+      if (provider !== prev.provider) {
+        // Save current provider's variables to per-provider storage (if we have a provider selected)
+        if (prev.provider && Object.keys(prev.variables).length > 0) {
+          const savedConfigs = JSON.parse(safeLocalStorage.getItem(STORAGE_KEYS.STT_PROVIDER_CONFIGS) || '{}');
+          savedConfigs[prev.provider] = prev.variables;
+          safeLocalStorage.setItem(STORAGE_KEYS.STT_PROVIDER_CONFIGS, JSON.stringify(savedConfigs));
+        }
+
+        // Load saved config for the new provider (if any)
+        const savedConfigs = JSON.parse(safeLocalStorage.getItem(STORAGE_KEYS.STT_PROVIDER_CONFIGS) || '{}');
+        const savedVariables = savedConfigs[provider] || {};
+
+        // Merge: saved config as base, then overlay with any passed variables
+        return {
+          provider,
+          variables: {
+            ...savedVariables,
+            ...variables,
+          }
+        };
+      }
+      // If provider is the same, merge variables to prevent stale closure issues
+      // This ensures that updating one variable (e.g., model) doesn't wipe out
+      // another variable (e.g., api_key) due to stale closure captures
+      return {
+        provider,
+        variables: {
+          ...prev.variables,
+          ...variables,
+        },
+      };
+    });
   };
 
   // Toggle handlers

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -19,3 +19,5 @@ export * from "./useTranslation";
 export * from "./useMeetingAudio";
 export * from "./useSpeakerDiarization";
 export * from "./useSetupStatus";
+export * from "./useSaveConversation";
+export * from "./usePricing";

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -18,3 +18,4 @@ export * from "./useQuickActions";
 export * from "./useTranslation";
 export * from "./useMeetingAudio";
 export * from "./useSpeakerDiarization";
+export * from "./useSetupStatus";

--- a/src/hooks/useMenuItems.tsx
+++ b/src/hooks/useMenuItems.tsx
@@ -1,6 +1,5 @@
 import {
   Settings,
-  Code,
   MessagesSquare,
   WandSparkles,
   AudioLinesIcon,
@@ -16,85 +15,102 @@ import {
   BrainIcon,
   UsersIcon,
   LanguagesIcon,
+  KeyRound,
 } from "lucide-react";
 import { invoke } from "@tauri-apps/api/core";
 import { useApp } from "@/contexts";
 import { GithubIcon } from "@/components";
+import { useSetupStatus } from "./useSetupStatus";
 
 export const useMenuItems = () => {
   const { hasActiveLicense } = useApp();
+  const { isComplete: setupComplete } = useSetupStatus();
 
   const menu: {
     icon: React.ElementType;
     label: string;
     href: string;
     count?: number;
+    disabled?: boolean;
+    showWarning?: boolean;
   }[] = [
     {
       icon: HomeIcon,
       label: "Dashboard",
       href: "/dashboard",
+      disabled: !setupComplete,
+    },
+    {
+      icon: KeyRound,
+      label: "API Setup",
+      href: "/api-setup",
+      showWarning: !setupComplete,
     },
     {
       icon: MessagesSquare,
       label: "Chats",
       href: "/chats",
+      disabled: !setupComplete,
     },
     {
       icon: WandSparkles,
       label: "System prompts",
       href: "/system-prompts",
+      disabled: !setupComplete,
     },
     {
       icon: Settings,
       label: "App Settings",
       href: "/settings",
+      disabled: !setupComplete,
     },
     {
       icon: MessageSquareTextIcon,
       label: "Responses",
       href: "/responses",
+      disabled: !setupComplete,
     },
     {
       icon: DollarSignIcon,
       label: "Cost Tracking",
       href: "/cost-tracking",
+      disabled: !setupComplete,
     },
     {
       icon: BrainIcon,
       label: "Context Memory",
       href: "/context-memory",
+      disabled: !setupComplete,
     },
     {
       icon: MonitorIcon,
       label: "Screenshot",
       href: "/screenshot",
+      disabled: !setupComplete,
     },
     {
       icon: AudioLinesIcon,
       label: "Audio",
       href: "/audio",
+      disabled: !setupComplete,
     },
     {
       icon: UsersIcon,
       label: "Speakers",
       href: "/speakers",
+      disabled: !setupComplete,
     },
     {
       icon: LanguagesIcon,
       label: "Language",
       href: "/language",
+      disabled: !setupComplete,
     },
     {
       icon: SquareSlashIcon,
       label: "Cursor & Shortcuts",
       href: "/shortcuts",
-    },
-
-    {
-      icon: Code,
-      label: "Dev space",
-      href: "/dev-space",
+      disabled: !setupComplete,
     },
   ];
 

--- a/src/hooks/usePricing.ts
+++ b/src/hooks/usePricing.ts
@@ -1,0 +1,213 @@
+/**
+ * usePricing Hook
+ *
+ * Provides pricing information for AI and STT models with estimation support.
+ * Centralizes pricing logic that was previously scattered in components.
+ */
+
+import { useMemo } from "react";
+import {
+  getModelPricing,
+  getSTTModelPricing,
+  formatCost,
+  getPricingConfig,
+  getSTTPricingConfig,
+} from "@/lib/storage/pricing.storage";
+
+export interface PricingInfo {
+  /** Formatted pricing text for display */
+  text: string;
+  /** Whether this is an estimated price (using fallback/wildcard) */
+  isEstimate: boolean;
+  /** Raw input cost per 1K tokens (AI only) */
+  inputPer1k?: number;
+  /** Raw output cost per 1K tokens (AI only) */
+  outputPer1k?: number;
+  /** Raw cost per minute (STT only) */
+  perMinute?: number;
+}
+
+export interface EstimatedCost {
+  /** Formatted estimated cost text */
+  text: string;
+  /** Whether this is an estimated price */
+  isEstimate: boolean;
+  /** Raw estimated cost value */
+  rawCost: number;
+}
+
+/**
+ * Check if pricing for a model is using fallback/estimated values.
+ * Returns true if using wildcard (*) pricing instead of exact model pricing.
+ */
+function isUsingFallbackPricing(
+  providerId: string,
+  modelId: string,
+  type: "ai" | "stt"
+): boolean {
+  if (type === "ai") {
+    const config = getPricingConfig();
+    const providerPricing = config[providerId];
+    if (!providerPricing) return true; // Using provider wildcard
+    if (providerPricing[modelId]) return false; // Exact match found
+    // Check if any pattern matches
+    for (const pattern of Object.keys(providerPricing)) {
+      if (
+        pattern !== "*" &&
+        modelId.toLowerCase().includes(pattern.toLowerCase())
+      ) {
+        return false; // Pattern match found
+      }
+    }
+    return true; // Using wildcard
+  } else {
+    const config = getSTTPricingConfig();
+    const providerPricing = config[providerId];
+    if (!providerPricing) return true;
+    if (providerPricing[modelId]) return false;
+    for (const pattern of Object.keys(providerPricing)) {
+      if (
+        pattern !== "*" &&
+        modelId.toLowerCase().includes(pattern.toLowerCase())
+      ) {
+        return false;
+      }
+    }
+    return true;
+  }
+}
+
+/**
+ * Format AI pricing for display
+ */
+export function formatAIPricing(
+  providerId: string,
+  modelId: string
+): PricingInfo {
+  const pricing = getModelPricing(providerId, modelId);
+  const isEstimate = isUsingFallbackPricing(providerId, modelId, "ai");
+
+  if (pricing.inputPer1k === 0 && pricing.outputPer1k === 0) {
+    return { text: "Free", isEstimate: false, inputPer1k: 0, outputPer1k: 0 };
+  }
+
+  return {
+    text: `$${pricing.inputPer1k}/$${pricing.outputPer1k} per 1K`,
+    isEstimate,
+    inputPer1k: pricing.inputPer1k,
+    outputPer1k: pricing.outputPer1k,
+  };
+}
+
+/**
+ * Format STT pricing for display
+ */
+export function formatSTTPricing(
+  providerId: string,
+  modelId: string
+): PricingInfo {
+  const pricing = getSTTModelPricing(providerId, modelId);
+  const isEstimate = isUsingFallbackPricing(providerId, modelId, "stt");
+
+  if (pricing.perMinute === 0) {
+    return { text: "Free", isEstimate: false, perMinute: 0 };
+  }
+
+  const text =
+    pricing.perMinute < 0.001
+      ? `$${pricing.perMinute.toFixed(5)}/min`
+      : `$${pricing.perMinute.toFixed(4)}/min`;
+
+  return { text, isEstimate, perMinute: pricing.perMinute };
+}
+
+/**
+ * Calculate estimated cost for typical usage
+ */
+export function getEstimatedCost(
+  providerId: string,
+  modelId: string,
+  type: "ai" | "stt"
+): EstimatedCost {
+  const isEstimate = isUsingFallbackPricing(providerId, modelId, type);
+
+  if (type === "ai") {
+    const pricing = getModelPricing(providerId, modelId);
+    if (pricing.inputPer1k === 0 && pricing.outputPer1k === 0) {
+      return { text: "Free (local model)", isEstimate: false, rawCost: 0 };
+    }
+    // Estimate based on 500 input + 500 output tokens (typical request)
+    const inputCost = (500 / 1000) * pricing.inputPer1k;
+    const outputCost = (500 / 1000) * pricing.outputPer1k;
+    const totalCost = inputCost + outputCost;
+    return {
+      text: `~${formatCost(totalCost)} per typical request (500 in/out tokens)`,
+      isEstimate,
+      rawCost: totalCost,
+    };
+  } else {
+    const pricing = getSTTModelPricing(providerId, modelId);
+    if (pricing.perMinute === 0) {
+      return { text: "Free (local model)", isEstimate: false, rawCost: 0 };
+    }
+    return {
+      text: `~${formatCost(pricing.perMinute)} per minute of audio`,
+      isEstimate,
+      rawCost: pricing.perMinute,
+    };
+  }
+}
+
+interface UsePricingOptions {
+  providerId: string;
+  modelId: string;
+  type: "ai" | "stt";
+}
+
+interface UsePricingReturn {
+  /** Pricing info for the model */
+  pricing: PricingInfo;
+  /** Estimated cost for typical usage */
+  estimatedCost: EstimatedCost | null;
+}
+
+/**
+ * Hook for getting pricing information for a model.
+ *
+ * Usage:
+ * ```tsx
+ * const { pricing, estimatedCost } = usePricing({
+ *   providerId: "openai",
+ *   modelId: "gpt-4o",
+ *   type: "ai",
+ * });
+ *
+ * return (
+ *   <div>
+ *     <span>{pricing.text}</span>
+ *     {pricing.isEstimate && <span>(estimated)</span>}
+ *   </div>
+ * );
+ * ```
+ */
+export function usePricing({
+  providerId,
+  modelId,
+  type,
+}: UsePricingOptions): UsePricingReturn {
+  const pricing = useMemo(() => {
+    if (!modelId) {
+      return { text: "—", isEstimate: false };
+    }
+    return type === "ai"
+      ? formatAIPricing(providerId, modelId)
+      : formatSTTPricing(providerId, modelId);
+  }, [providerId, modelId, type]);
+
+  const estimatedCost = useMemo(() => {
+    if (!modelId) return null;
+    return getEstimatedCost(providerId, modelId, type);
+  }, [providerId, modelId, type]);
+
+  return { pricing, estimatedCost };
+}

--- a/src/hooks/useSaveConversation.ts
+++ b/src/hooks/useSaveConversation.ts
@@ -1,0 +1,247 @@
+/**
+ * useSaveConversation Hook
+ *
+ * Provides debounced and queued conversation saving to prevent race conditions
+ * when multiple rapid saves occur (e.g., during streaming responses).
+ *
+ * Features:
+ * - Debounces saves to reduce database writes
+ * - Queues saves to ensure latest state is always persisted
+ * - Handles errors gracefully without losing data
+ * - Provides pending/saving status for UI feedback
+ */
+
+import { useCallback, useRef, useState, useEffect } from "react";
+import { ChatConversation } from "@/types";
+import { saveConversation } from "@/lib/database/chat-history.action";
+import { CONVERSATION_SAVE_DEBOUNCE_MS } from "@/lib/chat-constants";
+
+interface UseSaveConversationOptions {
+  /** Debounce delay in milliseconds (default: 500ms) */
+  debounceMs?: number;
+  /** Callback when save completes successfully */
+  onSaveSuccess?: (conversation: ChatConversation) => void;
+  /** Callback when save fails */
+  onSaveError?: (error: Error, conversation: ChatConversation) => void;
+}
+
+interface UseSaveConversationReturn {
+  /** Queue a conversation for saving (debounced) */
+  queueSave: (conversation: ChatConversation) => void;
+  /** Force immediate save of any pending conversation */
+  flushSave: () => Promise<void>;
+  /** Whether there's a pending save waiting for debounce */
+  hasPendingSave: boolean;
+  /** Whether a save is currently in progress */
+  isSaving: boolean;
+  /** The last error that occurred during save (cleared on next successful save) */
+  lastError: Error | null;
+}
+
+/**
+ * Hook for managing debounced conversation saves with queue support.
+ *
+ * Usage:
+ * ```tsx
+ * const { queueSave, flushSave, isSaving } = useSaveConversation({
+ *   onSaveSuccess: (conv) => console.log('Saved:', conv.id),
+ *   onSaveError: (error) => console.error('Save failed:', error),
+ * });
+ *
+ * // Queue a save (will be debounced)
+ * queueSave(conversation);
+ *
+ * // Force immediate save (e.g., before navigating away)
+ * await flushSave();
+ * ```
+ */
+export function useSaveConversation(
+  options: UseSaveConversationOptions = {}
+): UseSaveConversationReturn {
+  const {
+    debounceMs = CONVERSATION_SAVE_DEBOUNCE_MS,
+    onSaveSuccess,
+    onSaveError,
+  } = options;
+
+  // Track pending conversation to save (always keeps latest)
+  const pendingConversationRef = useRef<ChatConversation | null>(null);
+  // Track debounce timer
+  const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Track if a save is currently in progress
+  const isSavingRef = useRef(false);
+  // Track if component is mounted to avoid state updates after unmount
+  const isMountedRef = useRef(true);
+
+  // State for UI feedback
+  const [hasPendingSave, setHasPendingSave] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
+  const [lastError, setLastError] = useState<Error | null>(null);
+
+  // Cleanup on unmount
+  useEffect(() => {
+    isMountedRef.current = true;
+    return () => {
+      isMountedRef.current = false;
+      // Clear any pending timer
+      if (debounceTimerRef.current) {
+        clearTimeout(debounceTimerRef.current);
+      }
+    };
+  }, []);
+
+  /**
+   * Internal function to perform the actual save.
+   * Handles queue processing and error handling.
+   */
+  const performSave = useCallback(async () => {
+    // Don't start a new save if one is already in progress
+    if (isSavingRef.current) {
+      return;
+    }
+
+    // Get the pending conversation
+    const conversationToSave = pendingConversationRef.current;
+    if (!conversationToSave) {
+      return;
+    }
+
+    // Clear pending (will be set again if another save is queued during this save)
+    pendingConversationRef.current = null;
+    isSavingRef.current = true;
+
+    if (isMountedRef.current) {
+      setHasPendingSave(false);
+      setIsSaving(true);
+    }
+
+    try {
+      await saveConversation(conversationToSave);
+
+      if (isMountedRef.current) {
+        setLastError(null);
+      }
+
+      onSaveSuccess?.(conversationToSave);
+
+      // Check if another save was queued while we were saving
+      if (pendingConversationRef.current) {
+        // Process the next save in the queue
+        isSavingRef.current = false;
+        await performSave();
+      }
+    } catch (error) {
+      const errorObj = error instanceof Error ? error : new Error(String(error));
+
+      console.error("[useSaveConversation] Save failed:", errorObj);
+
+      if (isMountedRef.current) {
+        setLastError(errorObj);
+      }
+
+      onSaveError?.(errorObj, conversationToSave);
+
+      // Re-queue the failed save for retry
+      // Only if nothing newer has been queued
+      if (!pendingConversationRef.current) {
+        pendingConversationRef.current = conversationToSave;
+        if (isMountedRef.current) {
+          setHasPendingSave(true);
+        }
+      }
+    } finally {
+      isSavingRef.current = false;
+      if (isMountedRef.current) {
+        setIsSaving(false);
+      }
+    }
+  }, [onSaveSuccess, onSaveError]);
+
+  /**
+   * Queue a conversation for saving.
+   * Uses debouncing to batch rapid updates.
+   */
+  const queueSave = useCallback(
+    (conversation: ChatConversation) => {
+      // Always update to latest conversation
+      pendingConversationRef.current = conversation;
+
+      if (isMountedRef.current) {
+        setHasPendingSave(true);
+      }
+
+      // Clear existing timer
+      if (debounceTimerRef.current) {
+        clearTimeout(debounceTimerRef.current);
+      }
+
+      // Set new debounce timer
+      debounceTimerRef.current = setTimeout(() => {
+        debounceTimerRef.current = null;
+        performSave();
+      }, debounceMs);
+    },
+    [debounceMs, performSave]
+  );
+
+  /**
+   * Force immediate save of any pending conversation.
+   * Useful before navigation or when user explicitly saves.
+   */
+  const flushSave = useCallback(async () => {
+    // Clear debounce timer
+    if (debounceTimerRef.current) {
+      clearTimeout(debounceTimerRef.current);
+      debounceTimerRef.current = null;
+    }
+
+    // Perform save if there's anything pending
+    if (pendingConversationRef.current) {
+      await performSave();
+    }
+
+    // Wait for any in-progress save to complete
+    while (isSavingRef.current) {
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    }
+  }, [performSave]);
+
+  return {
+    queueSave,
+    flushSave,
+    hasPendingSave,
+    isSaving,
+    lastError,
+  };
+}
+
+/**
+ * Utility function for immediate (non-hook) save with retry.
+ * Use this for one-off saves outside of React components.
+ */
+export async function saveConversationWithRetry(
+  conversation: ChatConversation,
+  maxRetries: number = 3,
+  retryDelayMs: number = 1000
+): Promise<void> {
+  let lastError: Error | null = null;
+
+  for (let attempt = 1; attempt <= maxRetries; attempt++) {
+    try {
+      await saveConversation(conversation);
+      return;
+    } catch (error) {
+      lastError = error instanceof Error ? error : new Error(String(error));
+      console.warn(
+        `[saveConversationWithRetry] Attempt ${attempt}/${maxRetries} failed:`,
+        lastError.message
+      );
+
+      if (attempt < maxRetries) {
+        await new Promise((resolve) => setTimeout(resolve, retryDelayMs));
+      }
+    }
+  }
+
+  throw lastError;
+}

--- a/src/hooks/useSetupStatus.ts
+++ b/src/hooks/useSetupStatus.ts
@@ -1,0 +1,137 @@
+import { useApp } from "@/contexts";
+import { useMemo, useState, useEffect } from "react";
+import { TYPE_PROVIDER } from "@/types";
+import { isAIVerificationValid, isSTTVerificationValid } from "@/lib/storage";
+
+interface SetupStatus {
+  /** Whether the minimum required setup is complete (AI + STT configured AND verified) */
+  isComplete: boolean;
+  /** Whether an AI provider is selected and has an API key */
+  aiConfigured: boolean;
+  /** Whether an STT provider is selected and has an API key */
+  sttConfigured: boolean;
+  /** Whether the AI provider API key has been verified */
+  aiVerified: boolean;
+  /** Whether the STT provider API key has been verified */
+  sttVerified: boolean;
+  /** Completion percentage (0, 25, 50, 75, or 100) */
+  completionPercent: number;
+  /** Details about AI configuration */
+  aiDetails: {
+    providerSelected: boolean;
+    hasApiKey: boolean;
+    providerName: string | null;
+    modelName: string | null;
+  };
+  /** Details about STT configuration */
+  sttDetails: {
+    providerSelected: boolean;
+    hasApiKey: boolean;
+    providerName: string | null;
+    modelName: string | null;
+  };
+}
+
+/**
+ * Hook to check if the required API setup is complete.
+ * Used to determine if the app should redirect to setup or show warnings.
+ */
+export function useSetupStatus(): SetupStatus {
+  const {
+    selectedAIProvider,
+    selectedSttProvider,
+    allAiProviders,
+    allSttProviders,
+  } = useApp();
+
+  // This state forces a re-render when verification status changes
+  const [verificationTrigger, setVerificationTrigger] = useState(0);
+
+  // Listen for verification status changes
+  useEffect(() => {
+    const handleVerificationChange = () => {
+      setVerificationTrigger((prev) => prev + 1);
+    };
+
+    window.addEventListener("verification-status-changed", handleVerificationChange);
+    return () => {
+      window.removeEventListener("verification-status-changed", handleVerificationChange);
+    };
+  }, []);
+
+  return useMemo(() => {
+    // Check AI configuration
+    const aiProviderSelected = Boolean(selectedAIProvider?.provider);
+    const aiApiKey = selectedAIProvider?.variables?.api_key || "";
+    const aiHasApiKey = aiApiKey.trim().length > 0;
+    const aiConfigured = aiProviderSelected && aiHasApiKey;
+
+    // Get AI provider display name
+    const aiProvider = allAiProviders?.find(
+      (p: TYPE_PROVIDER) => p.id === selectedAIProvider?.provider
+    );
+    const aiProviderName = aiProvider?.isCustom
+      ? "Custom Provider"
+      : aiProvider?.name || selectedAIProvider?.provider || null;
+    const aiModelName = selectedAIProvider?.variables?.model || null;
+
+    // Check STT configuration
+    const sttProviderSelected = Boolean(selectedSttProvider?.provider);
+    const sttApiKey = selectedSttProvider?.variables?.api_key || "";
+    const sttHasApiKey = sttApiKey.trim().length > 0;
+    const sttConfigured = sttProviderSelected && sttHasApiKey;
+
+    // Get STT provider display name
+    const sttProvider = allSttProviders?.find(
+      (p: TYPE_PROVIDER) => p.id === selectedSttProvider?.provider
+    );
+    const sttProviderName = sttProvider?.isCustom
+      ? "Custom Provider"
+      : sttProvider?.name || selectedSttProvider?.provider || null;
+    const sttModelName = selectedSttProvider?.variables?.model || null;
+
+    // Check verification status
+    const aiVerified = aiConfigured && isAIVerificationValid(
+      selectedAIProvider?.provider || "",
+      selectedAIProvider?.variables?.model || "",
+      aiApiKey
+    );
+    const sttVerified = sttConfigured && isSTTVerificationValid(
+      selectedSttProvider?.provider || "",
+      selectedSttProvider?.variables?.model || "",
+      sttApiKey
+    );
+
+    // Calculate completion (4 steps: AI configured, AI verified, STT configured, STT verified)
+    let completedSteps = 0;
+    if (aiConfigured) completedSteps++;
+    if (aiVerified) completedSteps++;
+    if (sttConfigured) completedSteps++;
+    if (sttVerified) completedSteps++;
+    const completionPercent = (completedSteps / 4) * 100;
+
+    // App is only complete when both are configured AND verified
+    const isComplete = aiVerified && sttVerified;
+
+    return {
+      isComplete,
+      aiConfigured,
+      sttConfigured,
+      aiVerified,
+      sttVerified,
+      completionPercent,
+      aiDetails: {
+        providerSelected: aiProviderSelected,
+        hasApiKey: aiHasApiKey,
+        providerName: aiProviderName,
+        modelName: aiModelName,
+      },
+      sttDetails: {
+        providerSelected: sttProviderSelected,
+        hasApiKey: sttHasApiKey,
+        providerName: sttProviderName,
+        modelName: sttModelName,
+      },
+    };
+  }, [selectedAIProvider, selectedSttProvider, allAiProviders, allSttProviders, verificationTrigger]);
+}

--- a/src/hooks/useSetupStatus.ts
+++ b/src/hooks/useSetupStatus.ts
@@ -86,14 +86,21 @@ export function useSetupStatus(): SetupStatus {
     };
   }, []);
 
-  // Compute configuration status (sync)
-  const aiProviderSelected = Boolean(selectedAIProvider?.provider);
+  // Extract provider values for dependency tracking
+  const aiProviderId = selectedAIProvider?.provider || "";
+  const aiModel = selectedAIProvider?.variables?.model || "";
   const aiApiKey = selectedAIProvider?.variables?.api_key || "";
+
+  const sttProviderId = selectedSttProvider?.provider || "";
+  const sttModel = selectedSttProvider?.variables?.model || "";
+  const sttApiKey = selectedSttProvider?.variables?.api_key || "";
+
+  // Compute configuration status (sync)
+  const aiProviderSelected = Boolean(aiProviderId);
   const aiHasApiKey = aiApiKey.trim().length > 0;
   const aiConfigured = aiProviderSelected && aiHasApiKey;
 
-  const sttProviderSelected = Boolean(selectedSttProvider?.provider);
-  const sttApiKey = selectedSttProvider?.variables?.api_key || "";
+  const sttProviderSelected = Boolean(sttProviderId);
   const sttHasApiKey = sttApiKey.trim().length > 0;
   const sttConfigured = sttProviderSelected && sttHasApiKey;
 
@@ -118,11 +125,7 @@ export function useSetupStatus(): SetupStatus {
   const checkVerificationStatus = useCallback(async () => {
     try {
       if (aiConfigured) {
-        const valid = await isAIVerificationValid(
-          selectedAIProvider?.provider || "",
-          selectedAIProvider?.variables?.model || "",
-          aiApiKey
-        );
+        const valid = await isAIVerificationValid(aiProviderId, aiModel, aiApiKey);
         setAiVerified(valid);
       } else {
         setAiVerified(false);
@@ -134,11 +137,7 @@ export function useSetupStatus(): SetupStatus {
 
     try {
       if (sttConfigured) {
-        const valid = await isSTTVerificationValid(
-          selectedSttProvider?.provider || "",
-          selectedSttProvider?.variables?.model || "",
-          sttApiKey
-        );
+        const valid = await isSTTVerificationValid(sttProviderId, sttModel, sttApiKey);
         setSttVerified(valid);
       } else {
         setSttVerified(false);
@@ -147,16 +146,7 @@ export function useSetupStatus(): SetupStatus {
       console.error("[useSetupStatus] Error checking STT verification:", error);
       setSttVerified(false);
     }
-  }, [
-    aiConfigured,
-    sttConfigured,
-    selectedAIProvider?.provider,
-    selectedAIProvider?.variables?.model,
-    aiApiKey,
-    selectedSttProvider?.provider,
-    selectedSttProvider?.variables?.model,
-    sttApiKey,
-  ]);
+  }, [aiConfigured, sttConfigured, aiProviderId, aiModel, aiApiKey, sttProviderId, sttModel, sttApiKey]);
 
   // Run verification check when dependencies change
   useEffect(() => {

--- a/src/hooks/useSetupStatus.ts
+++ b/src/hooks/useSetupStatus.ts
@@ -116,25 +116,35 @@ export function useSetupStatus(): SetupStatus {
 
   // Check verification status asynchronously
   const checkVerificationStatus = useCallback(async () => {
-    if (aiConfigured) {
-      const valid = await isAIVerificationValid(
-        selectedAIProvider?.provider || "",
-        selectedAIProvider?.variables?.model || "",
-        aiApiKey
-      );
-      setAiVerified(valid);
-    } else {
+    try {
+      if (aiConfigured) {
+        const valid = await isAIVerificationValid(
+          selectedAIProvider?.provider || "",
+          selectedAIProvider?.variables?.model || "",
+          aiApiKey
+        );
+        setAiVerified(valid);
+      } else {
+        setAiVerified(false);
+      }
+    } catch (error) {
+      console.error("[useSetupStatus] Error checking AI verification:", error);
       setAiVerified(false);
     }
 
-    if (sttConfigured) {
-      const valid = await isSTTVerificationValid(
-        selectedSttProvider?.provider || "",
-        selectedSttProvider?.variables?.model || "",
-        sttApiKey
-      );
-      setSttVerified(valid);
-    } else {
+    try {
+      if (sttConfigured) {
+        const valid = await isSTTVerificationValid(
+          selectedSttProvider?.provider || "",
+          selectedSttProvider?.variables?.model || "",
+          sttApiKey
+        );
+        setSttVerified(valid);
+      } else {
+        setSttVerified(false);
+      }
+    } catch (error) {
+      console.error("[useSetupStatus] Error checking STT verification:", error);
       setSttVerified(false);
     }
   }, [

--- a/src/layouts/DashboardLayout.tsx
+++ b/src/layouts/DashboardLayout.tsx
@@ -1,9 +1,22 @@
 import { Sidebar } from "@/components";
-import { Outlet } from "react-router-dom";
+import { Outlet, useLocation, useNavigate } from "react-router-dom";
 import { ErrorBoundary } from "react-error-boundary";
 import { ErrorLayout } from "./ErrorLayout";
+import { useSetupStatus } from "@/hooks";
+import { useEffect } from "react";
 
 export const DashboardLayout = () => {
+  const { isComplete } = useSetupStatus();
+  const location = useLocation();
+  const navigate = useNavigate();
+
+  // Redirect to API Setup if not configured
+  useEffect(() => {
+    if (!isComplete && location.pathname !== "/api-setup") {
+      navigate("/api-setup", { replace: true });
+    }
+  }, [isComplete, location.pathname, navigate]);
+
   return (
     <ErrorBoundary
       fallbackRender={() => {

--- a/src/lib/chat-constants.ts
+++ b/src/lib/chat-constants.ts
@@ -92,17 +92,21 @@ export function generateConversationId(
  *
  * @param role - The role of the message ('user', 'assistant', or 'system')
  * @param timestamp - Optional timestamp (defaults to Date.now())
- * @returns A unique message ID in the format: msg_{timestamp}_{role}
+ * @returns A unique message ID in the format: msg_{timestamp}_{random}_{role}
  *
  * Examples:
- * - msg_1696291234567_user
- * - msg_1696291234568_assistant
+ * - msg_1696291234567_k3j9_user
+ * - msg_1696291234568_m2n4_assistant
+ *
+ * Note: Random suffix ensures uniqueness even if multiple messages
+ * are created at the same millisecond with the same role.
  */
 export function generateMessageId(
   role: "user" | "assistant" | "system",
   timestamp: number = Date.now()
 ): string {
-  return `msg_${timestamp}_${role}`;
+  const random = Math.random().toString(36).substring(2, 6);
+  return `msg_${timestamp}_${random}_${role}`;
 }
 
 /**
@@ -135,7 +139,10 @@ export function isValidConversationId(id: string): boolean {
  *
  * @param id - The ID to validate
  * @returns true if the ID matches the expected format
+ *
+ * Supports both old format (msg_{timestamp}_{role}) and
+ * new format (msg_{timestamp}_{random}_{role})
  */
 export function isValidMessageId(id: string): boolean {
-  return /^msg_\d+_(user|assistant|system)$/.test(id);
+  return /^msg_\d+_([a-z0-9]{4}_)?(user|assistant|system)$/.test(id);
 }

--- a/src/lib/database/chat-history.action.ts
+++ b/src/lib/database/chat-history.action.ts
@@ -283,9 +283,20 @@ export async function updateConversation(
       conversation.id,
     ]);
 
+    // Deduplicate messages by ID (keep first occurrence to preserve order)
+    const seenIds = new Set<string>();
+    const uniqueMessages = conversation.messages.filter((msg) => {
+      if (seenIds.has(msg.id)) {
+        console.warn(`[ChatHistory] Skipping duplicate message ID: ${msg.id}`);
+        return false;
+      }
+      seenIds.add(msg.id);
+      return true;
+    });
+
     // Insert updated messages
     try {
-      for (const message of conversation.messages) {
+      for (const message of uniqueMessages) {
         if (!validateMessage(message)) {
           console.warn("Skipping invalid message in conversation update");
           continue;

--- a/src/lib/functions/api-test.function.ts
+++ b/src/lib/functions/api-test.function.ts
@@ -1,0 +1,410 @@
+/**
+ * API Connection Test Functions
+ *
+ * These functions perform minimal API requests to verify that the configured
+ * API keys are valid and working before unlocking the app.
+ */
+
+import { TYPE_PROVIDER } from "@/types";
+import { fetch as tauriFetch } from "@tauri-apps/plugin-http";
+import curl2Json from "@bany/curl-to-json";
+import {
+  deepVariableReplacer,
+  extractVariables,
+  getByPath,
+} from "./common.function";
+
+export interface TestResult {
+  success: boolean;
+  message: string;
+  error?: string;
+}
+
+/**
+ * Tests an AI provider connection by making a minimal completion request.
+ * Sends a simple "Say hello" prompt and checks for a valid response.
+ */
+export async function testAIProvider(
+  provider: TYPE_PROVIDER | undefined,
+  selectedProvider: {
+    provider: string;
+    variables: Record<string, string>;
+  }
+): Promise<TestResult> {
+  try {
+    if (!provider) {
+      return { success: false, message: "No provider configured", error: "Provider not found" };
+    }
+
+    if (!selectedProvider?.variables?.api_key) {
+      return { success: false, message: "API key not provided", error: "Missing API key" };
+    }
+
+    let curlJson;
+    try {
+      curlJson = curl2Json(provider.curl);
+    } catch (error) {
+      return {
+        success: false,
+        message: "Invalid provider configuration",
+        error: error instanceof Error ? error.message : "Failed to parse curl",
+      };
+    }
+
+    // Check for required variables
+    const extractedVariables = extractVariables(provider.curl);
+    const requiredVars = extractedVariables.filter(
+      ({ key }) => key !== "SYSTEM_PROMPT" && key !== "TEXT" && key !== "IMAGE"
+    );
+    for (const { key } of requiredVars) {
+      if (!selectedProvider.variables?.[key] || selectedProvider.variables[key].trim() === "") {
+        return {
+          success: false,
+          message: `Missing required: ${key.replace(/_/g, " ")}`,
+          error: `Missing variable: ${key}`,
+        };
+      }
+    }
+
+    // Build request body with minimal test message
+    let bodyObj: any = curlJson.data ? JSON.parse(JSON.stringify(curlJson.data)) : {};
+    const messagesKey = Object.keys(bodyObj).find((key) =>
+      ["messages", "contents", "conversation", "history"].includes(key)
+    );
+
+    if (messagesKey && Array.isArray(bodyObj[messagesKey])) {
+      // Replace with a simple test message
+      bodyObj[messagesKey] = [
+        { role: "user", content: "Say 'OK' and nothing else." },
+      ];
+    }
+
+    const allVariables = {
+      ...Object.fromEntries(
+        Object.entries(selectedProvider.variables).map(([key, value]) => [
+          key.toUpperCase(),
+          value,
+        ])
+      ),
+      SYSTEM_PROMPT: "You are a test assistant. Respond with only 'OK'.",
+    };
+
+    bodyObj = deepVariableReplacer(bodyObj, allVariables);
+    const url = deepVariableReplacer(curlJson.url || "", allVariables);
+    const headers = deepVariableReplacer(curlJson.header || {}, allVariables);
+    headers["Content-Type"] = "application/json";
+
+    // Disable streaming for test
+    if (typeof bodyObj === "object" && bodyObj !== null) {
+      const streamKey = Object.keys(bodyObj).find((k) => k.toLowerCase() === "stream");
+      if (streamKey) {
+        bodyObj[streamKey] = false;
+      } else {
+        bodyObj.stream = false;
+      }
+      // Remove stream_options if present
+      delete bodyObj.stream_options;
+    }
+
+    // Limit response tokens for faster test
+    if (typeof bodyObj === "object" && bodyObj !== null) {
+      bodyObj.max_tokens = 10;
+    }
+
+    const fetchFunction = url?.includes("http") ? fetch : tauriFetch;
+
+    const response = await fetchFunction(url, {
+      method: curlJson.method || "POST",
+      headers,
+      body: curlJson.method === "GET" ? undefined : JSON.stringify(bodyObj),
+    });
+
+    if (!response.ok) {
+      let errorText = "";
+      try {
+        errorText = await response.text();
+      } catch {}
+
+      // Parse common error patterns
+      if (response.status === 401 || response.status === 403) {
+        return {
+          success: false,
+          message: "Invalid API key",
+          error: `Authentication failed (${response.status})`,
+        };
+      }
+
+      if (response.status === 429) {
+        // Rate limited but key is valid
+        return {
+          success: true,
+          message: "API key verified (rate limited)",
+        };
+      }
+
+      return {
+        success: false,
+        message: `API error: ${response.status}`,
+        error: errorText || response.statusText,
+      };
+    }
+
+    // Parse response to verify we got actual content
+    let json;
+    try {
+      json = await response.json();
+    } catch {
+      return {
+        success: false,
+        message: "Invalid response format",
+        error: "Failed to parse JSON response",
+      };
+    }
+
+    const content = getByPath(json, provider?.responseContentPath || "") || "";
+    if (content || json) {
+      return {
+        success: true,
+        message: "Connection verified",
+      };
+    }
+
+    return {
+      success: false,
+      message: "Empty response",
+      error: "No content in response",
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+
+    // Check for network errors
+    if (message.includes("network") || message.includes("fetch")) {
+      return {
+        success: false,
+        message: "Network error",
+        error: message,
+      };
+    }
+
+    return {
+      success: false,
+      message: "Connection failed",
+      error: message,
+    };
+  }
+}
+
+/**
+ * Tests an STT provider connection.
+ *
+ * For STT, we can't easily test without audio. Instead, we make a request
+ * with minimal/empty audio to verify the API key is valid. Most providers
+ * will return a specific error for invalid keys vs processing errors.
+ */
+export async function testSTTProvider(
+  provider: TYPE_PROVIDER | undefined,
+  selectedProvider: {
+    provider: string;
+    variables: Record<string, string>;
+  }
+): Promise<TestResult> {
+  try {
+    if (!provider) {
+      return { success: false, message: "No provider configured", error: "Provider not found" };
+    }
+
+    if (!selectedProvider?.variables?.api_key) {
+      return { success: false, message: "API key not provided", error: "Missing API key" };
+    }
+
+    // For AssemblyAI special handler, we can test by making a simple API call
+    if (provider.requiresSpecialHandler && provider.specialHandler === "assemblyai-diarization") {
+      const apiKey = selectedProvider.variables?.API_KEY || selectedProvider.variables?.api_key;
+      if (!apiKey) {
+        return { success: false, message: "API key not provided", error: "Missing API key" };
+      }
+
+      // Test AssemblyAI by checking the API with a simple request
+      try {
+        const response = await tauriFetch("https://api.assemblyai.com/v2/transcript", {
+          method: "GET",
+          headers: {
+            Authorization: apiKey,
+          },
+        });
+
+        // 401 = invalid key, 200/other = valid key
+        if (response.status === 401) {
+          return {
+            success: false,
+            message: "Invalid API key",
+            error: "AssemblyAI authentication failed",
+          };
+        }
+
+        // Any other response means the key is valid
+        return {
+          success: true,
+          message: "Connection verified",
+        };
+      } catch (error) {
+        return {
+          success: false,
+          message: "Network error",
+          error: error instanceof Error ? error.message : "Connection failed",
+        };
+      }
+    }
+
+    let curlJson;
+    try {
+      curlJson = curl2Json(provider.curl);
+    } catch (error) {
+      return {
+        success: false,
+        message: "Invalid provider configuration",
+        error: error instanceof Error ? error.message : "Failed to parse curl",
+      };
+    }
+
+    // Build variable map
+    const allVariables: Record<string, string> = {
+      ...Object.fromEntries(
+        Object.entries(selectedProvider.variables).map(([key, value]) => [
+          key.toUpperCase(),
+          value,
+        ])
+      ),
+      LANGUAGE: "en",
+    };
+
+    let url = deepVariableReplacer(curlJson.url || "", allVariables);
+    const headers = deepVariableReplacer(curlJson.header || {}, allVariables);
+
+    // For OpenAI/Groq Whisper style APIs, we can test with a tiny valid WAV file
+    // This is a minimal valid WAV header (44 bytes) with no audio data
+    const minimalWavHeader = new Uint8Array([
+      0x52, 0x49, 0x46, 0x46, // "RIFF"
+      0x24, 0x00, 0x00, 0x00, // File size (36 bytes)
+      0x57, 0x41, 0x56, 0x45, // "WAVE"
+      0x66, 0x6d, 0x74, 0x20, // "fmt "
+      0x10, 0x00, 0x00, 0x00, // Subchunk1 size (16)
+      0x01, 0x00, // Audio format (1 = PCM)
+      0x01, 0x00, // Num channels (1)
+      0x80, 0x3e, 0x00, 0x00, // Sample rate (16000)
+      0x00, 0x7d, 0x00, 0x00, // Byte rate
+      0x02, 0x00, // Block align
+      0x10, 0x00, // Bits per sample (16)
+      0x64, 0x61, 0x74, 0x61, // "data"
+      0x00, 0x00, 0x00, 0x00, // Data size (0)
+    ]);
+
+    const isForm = provider.curl.includes("-F ") || provider.curl.includes("--form");
+    const isBinaryUpload = provider.curl.includes("--data-binary");
+
+    let body: FormData | Blob;
+    let finalHeaders = { ...headers };
+
+    if (isForm) {
+      const form = new FormData();
+      const testBlob = new Blob([minimalWavHeader], { type: "audio/wav" });
+      form.append("file", testBlob, "test.wav");
+
+      // Add model if required
+      if (allVariables.MODEL) {
+        form.append("model", allVariables.MODEL);
+      }
+
+      delete finalHeaders["Content-Type"];
+      body = form;
+    } else if (isBinaryUpload) {
+      body = new Blob([minimalWavHeader], { type: "audio/wav" });
+    } else {
+      // For non-form APIs, we need to send audio as base64
+      // This minimal approach might not work for all providers
+      return {
+        success: true,
+        message: "Configuration looks valid",
+      };
+    }
+
+    // Add query params if present
+    const rawParams = curlJson.params || {};
+    const decodedParams = Object.fromEntries(
+      Object.entries(rawParams).map(([key, value]) => [
+        key,
+        typeof value === "string" ? decodeURIComponent(value) : "",
+      ])
+    );
+    const replacedParams = deepVariableReplacer(decodedParams, allVariables);
+    const queryString = new URLSearchParams(replacedParams).toString();
+    if (queryString) {
+      url += (url.includes("?") ? "&" : "?") + queryString;
+    }
+
+    const fetchFunction = url?.includes("http") ? tauriFetch : fetch;
+
+    const response = await fetchFunction(url, {
+      method: curlJson.method || "POST",
+      headers: finalHeaders,
+      body,
+    });
+
+    // Check response status
+    if (response.status === 401 || response.status === 403) {
+      return {
+        success: false,
+        message: "Invalid API key",
+        error: `Authentication failed (${response.status})`,
+      };
+    }
+
+    if (response.status === 429) {
+      // Rate limited but key is valid
+      return {
+        success: true,
+        message: "API key verified (rate limited)",
+      };
+    }
+
+    // 400 Bad Request is expected for empty/minimal audio - key is valid
+    if (response.status === 400) {
+      const errorText = await response.text().catch(() => "");
+      // Check if it's an auth error disguised as 400
+      if (errorText.toLowerCase().includes("api key") || errorText.toLowerCase().includes("unauthorized")) {
+        return {
+          success: false,
+          message: "Invalid API key",
+          error: errorText,
+        };
+      }
+      // Otherwise, the key is valid but audio was rejected
+      return {
+        success: true,
+        message: "API key verified",
+      };
+    }
+
+    if (response.ok) {
+      return {
+        success: true,
+        message: "Connection verified",
+      };
+    }
+
+    // Other errors
+    const errorText = await response.text().catch(() => response.statusText);
+    return {
+      success: false,
+      message: `API error: ${response.status}`,
+      error: errorText,
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return {
+      success: false,
+      message: "Connection failed",
+      error: message,
+    };
+  }
+}

--- a/src/lib/functions/api-test.function.ts
+++ b/src/lib/functions/api-test.function.ts
@@ -20,54 +20,244 @@ export interface TestResult {
   error?: string;
 }
 
+/** Request body type for API calls */
+type RequestBody = Record<string, unknown>;
+
+/** Parsed curl configuration */
+interface ParsedCurl {
+  url?: string;
+  method?: string;
+  header?: Record<string, string>;
+  data?: RequestBody;
+  params?: Record<string, string>;
+}
+
+/** Selected provider configuration */
+interface SelectedProviderConfig {
+  provider: string;
+  variables: Record<string, string>;
+}
+
+/** Default timeout for API test requests (10 seconds) */
+const API_TEST_TIMEOUT_MS = 10000;
+
+/**
+ * Standardized error message prefixes for consistent user experience.
+ */
+const ErrorMessages = {
+  // Configuration errors
+  CONFIG_NO_PROVIDER: "Configuration error: No provider configured",
+  CONFIG_NO_API_KEY: "Configuration error: API key not provided",
+  CONFIG_MISSING_REQUIRED: (field: string) => `Configuration error: Missing ${field}`,
+  CONFIG_INVALID: "Configuration error: Invalid provider configuration",
+  CONFIG_UNSUPPORTED: "Configuration error: API format not supported for verification",
+
+  // Authentication errors
+  AUTH_INVALID_KEY: "Authentication failed: Invalid API key",
+  AUTH_RATE_LIMITED: "Authentication verified (rate limited)",
+
+  // Network errors
+  NETWORK_TIMEOUT: "Network error: Connection timed out",
+  NETWORK_ERROR: "Network error: Connection failed",
+
+  // Response errors
+  RESPONSE_INVALID: "Response error: Invalid response format",
+  RESPONSE_EMPTY: "Response error: Empty response",
+  RESPONSE_API_ERROR: (status: number) => `Response error: API returned ${status}`,
+
+  // Success messages
+  SUCCESS_VERIFIED: "Connection verified",
+  SUCCESS_KEY_VERIFIED: "API key verified",
+} as const;
+
+/**
+ * Validates that provider and API key are configured.
+ * Returns a TestResult error if validation fails, null if valid.
+ */
+function validateProviderConfig(
+  provider: TYPE_PROVIDER | undefined,
+  selectedProvider: SelectedProviderConfig | undefined
+): TestResult | null {
+  if (!provider) {
+    return { success: false, message: ErrorMessages.CONFIG_NO_PROVIDER, error: "Provider not found" };
+  }
+
+  if (!selectedProvider?.variables?.api_key) {
+    return { success: false, message: ErrorMessages.CONFIG_NO_API_KEY, error: "Missing API key" };
+  }
+
+  return null;
+}
+
+/**
+ * Parses the curl template and validates required variables.
+ * Returns a TestResult error if parsing fails or required variables are missing.
+ */
+function parseCurlTemplate(
+  provider: TYPE_PROVIDER,
+  selectedProvider: SelectedProviderConfig
+): { curlJson: ParsedCurl; error: null } | { curlJson: null; error: TestResult } {
+  let curlJson: ParsedCurl;
+  try {
+    curlJson = curl2Json(provider.curl) as ParsedCurl;
+  } catch (error) {
+    return {
+      curlJson: null,
+      error: {
+        success: false,
+        message: ErrorMessages.CONFIG_INVALID,
+        error: error instanceof Error ? error.message : "Failed to parse curl",
+      },
+    };
+  }
+
+  // Check for required variables (skip SYSTEM_PROMPT, TEXT, IMAGE which are injected at runtime)
+  const extractedVariables = extractVariables(provider.curl);
+  const requiredVars = extractedVariables.filter(
+    ({ key }) => key !== "SYSTEM_PROMPT" && key !== "TEXT" && key !== "IMAGE"
+  );
+
+  for (const { key } of requiredVars) {
+    if (!selectedProvider.variables?.[key] || selectedProvider.variables[key].trim() === "") {
+      return {
+        curlJson: null,
+        error: {
+          success: false,
+          message: ErrorMessages.CONFIG_MISSING_REQUIRED(key.replace(/_/g, " ")),
+          error: `Missing variable: ${key}`,
+        },
+      };
+    }
+  }
+
+  return { curlJson, error: null };
+}
+
+/**
+ * Handles common HTTP response status codes.
+ * Returns a TestResult if the status is handled, null if the caller should continue processing.
+ */
+async function handleResponseStatus(response: Response): Promise<TestResult | null> {
+  // Authentication errors
+  if (response.status === 401 || response.status === 403) {
+    return {
+      success: false,
+      message: ErrorMessages.AUTH_INVALID_KEY,
+      error: `HTTP ${response.status}`,
+    };
+  }
+
+  // Rate limited but key is valid
+  if (response.status === 429) {
+    return {
+      success: true,
+      message: ErrorMessages.AUTH_RATE_LIMITED,
+    };
+  }
+
+  return null;
+}
+
+/**
+ * Handles fetch errors and converts them to TestResult.
+ */
+function handleFetchError(error: unknown): TestResult {
+  const message = error instanceof Error ? error.message : String(error);
+
+  // Check for timeout errors
+  if (message.includes("timed out")) {
+    return {
+      success: false,
+      message: ErrorMessages.NETWORK_TIMEOUT,
+      error: message,
+    };
+  }
+
+  // Check for network errors
+  if (message.includes("network") || message.includes("fetch")) {
+    return {
+      success: false,
+      message: ErrorMessages.NETWORK_ERROR,
+      error: message,
+    };
+  }
+
+  return {
+    success: false,
+    message: ErrorMessages.NETWORK_ERROR,
+    error: message,
+  };
+}
+
+/**
+ * Builds a variable map from selected provider variables.
+ * Converts all keys to uppercase for template replacement.
+ */
+function buildVariableMap(
+  selectedProvider: SelectedProviderConfig,
+  additionalVars: Record<string, string> = {}
+): Record<string, string> {
+  return {
+    ...Object.fromEntries(
+      Object.entries(selectedProvider.variables).map(([key, value]) => [
+        key.toUpperCase(),
+        value,
+      ])
+    ),
+    ...additionalVars,
+  };
+}
+
+/**
+ * Fetch wrapper with timeout support.
+ * Aborts the request if it takes longer than the specified timeout.
+ */
+async function fetchWithTimeout(
+  fetchFn: typeof fetch,
+  url: string,
+  options: RequestInit,
+  timeoutMs: number = API_TEST_TIMEOUT_MS
+): Promise<Response> {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    const response = await fetchFn(url, {
+      ...options,
+      signal: controller.signal,
+    });
+    clearTimeout(timeoutId);
+    return response;
+  } catch (error) {
+    clearTimeout(timeoutId);
+    // Convert AbortError to a more descriptive timeout error
+    if (error instanceof Error && error.name === "AbortError") {
+      throw new Error(`Request timed out after ${timeoutMs / 1000} seconds`);
+    }
+    throw error;
+  }
+}
+
 /**
  * Tests an AI provider connection by making a minimal completion request.
  * Sends a simple "Say hello" prompt and checks for a valid response.
  */
 export async function testAIProvider(
   provider: TYPE_PROVIDER | undefined,
-  selectedProvider: {
-    provider: string;
-    variables: Record<string, string>;
-  }
+  selectedProvider: SelectedProviderConfig
 ): Promise<TestResult> {
   try {
-    if (!provider) {
-      return { success: false, message: "No provider configured", error: "Provider not found" };
-    }
+    // Validate provider and API key configuration
+    const validationError = validateProviderConfig(provider, selectedProvider);
+    if (validationError) return validationError;
 
-    if (!selectedProvider?.variables?.api_key) {
-      return { success: false, message: "API key not provided", error: "Missing API key" };
-    }
-
-    let curlJson;
-    try {
-      curlJson = curl2Json(provider.curl);
-    } catch (error) {
-      return {
-        success: false,
-        message: "Invalid provider configuration",
-        error: error instanceof Error ? error.message : "Failed to parse curl",
-      };
-    }
-
-    // Check for required variables
-    const extractedVariables = extractVariables(provider.curl);
-    const requiredVars = extractedVariables.filter(
-      ({ key }) => key !== "SYSTEM_PROMPT" && key !== "TEXT" && key !== "IMAGE"
-    );
-    for (const { key } of requiredVars) {
-      if (!selectedProvider.variables?.[key] || selectedProvider.variables[key].trim() === "") {
-        return {
-          success: false,
-          message: `Missing required: ${key.replace(/_/g, " ")}`,
-          error: `Missing variable: ${key}`,
-        };
-      }
-    }
+    // Parse curl template and validate required variables
+    const parseResult = parseCurlTemplate(provider!, selectedProvider);
+    if (parseResult.error) return parseResult.error;
+    const { curlJson } = parseResult;
 
     // Build request body with minimal test message
-    let bodyObj: any = curlJson.data ? JSON.parse(JSON.stringify(curlJson.data)) : {};
+    let bodyObj: RequestBody = curlJson.data ? JSON.parse(JSON.stringify(curlJson.data)) : {};
     const messagesKey = Object.keys(bodyObj).find((key) =>
       ["messages", "contents", "conversation", "history"].includes(key)
     );
@@ -79,19 +269,14 @@ export async function testAIProvider(
       ];
     }
 
-    const allVariables = {
-      ...Object.fromEntries(
-        Object.entries(selectedProvider.variables).map(([key, value]) => [
-          key.toUpperCase(),
-          value,
-        ])
-      ),
+    // Build variables for template replacement
+    const allVariables = buildVariableMap(selectedProvider, {
       SYSTEM_PROMPT: "You are a test assistant. Respond with only 'OK'.",
-    };
+    });
 
-    bodyObj = deepVariableReplacer(bodyObj, allVariables);
-    const url = deepVariableReplacer(curlJson.url || "", allVariables);
-    const headers = deepVariableReplacer(curlJson.header || {}, allVariables);
+    bodyObj = deepVariableReplacer(bodyObj, allVariables) as RequestBody;
+    const url = deepVariableReplacer(curlJson.url || "", allVariables) as string;
+    const headers = deepVariableReplacer(curlJson.header || {}, allVariables) as Record<string, string>;
     headers["Content-Type"] = "application/json";
 
     // Disable streaming for test
@@ -113,50 +298,33 @@ export async function testAIProvider(
 
     const fetchFunction = url?.includes("http") ? fetch : tauriFetch;
 
-    const response = await fetchFunction(url, {
+    const response = await fetchWithTimeout(fetchFunction, url, {
       method: curlJson.method || "POST",
       headers,
       body: curlJson.method === "GET" ? undefined : JSON.stringify(bodyObj),
     });
 
+    // Handle common response status codes
+    const statusResult = await handleResponseStatus(response);
+    if (statusResult) return statusResult;
+
     if (!response.ok) {
-      let errorText = "";
-      try {
-        errorText = await response.text();
-      } catch {}
-
-      // Parse common error patterns
-      if (response.status === 401 || response.status === 403) {
-        return {
-          success: false,
-          message: "Invalid API key",
-          error: `Authentication failed (${response.status})`,
-        };
-      }
-
-      if (response.status === 429) {
-        // Rate limited but key is valid
-        return {
-          success: true,
-          message: "API key verified (rate limited)",
-        };
-      }
-
+      const errorText = await response.text().catch(() => response.statusText);
       return {
         success: false,
-        message: `API error: ${response.status}`,
-        error: errorText || response.statusText,
+        message: ErrorMessages.RESPONSE_API_ERROR(response.status),
+        error: errorText,
       };
     }
 
     // Parse response to verify we got actual content
-    let json;
+    let json: unknown;
     try {
       json = await response.json();
     } catch {
       return {
         success: false,
-        message: "Invalid response format",
+        message: ErrorMessages.RESPONSE_INVALID,
         error: "Failed to parse JSON response",
       };
     }
@@ -165,32 +333,17 @@ export async function testAIProvider(
     if (content || json) {
       return {
         success: true,
-        message: "Connection verified",
+        message: ErrorMessages.SUCCESS_VERIFIED,
       };
     }
 
     return {
       success: false,
-      message: "Empty response",
+      message: ErrorMessages.RESPONSE_EMPTY,
       error: "No content in response",
     };
   } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-
-    // Check for network errors
-    if (message.includes("network") || message.includes("fetch")) {
-      return {
-        success: false,
-        message: "Network error",
-        error: message,
-      };
-    }
-
-    return {
-      success: false,
-      message: "Connection failed",
-      error: message,
-    };
+    return handleFetchError(error);
   }
 }
 
@@ -203,83 +356,69 @@ export async function testAIProvider(
  */
 export async function testSTTProvider(
   provider: TYPE_PROVIDER | undefined,
-  selectedProvider: {
-    provider: string;
-    variables: Record<string, string>;
-  }
+  selectedProvider: SelectedProviderConfig
 ): Promise<TestResult> {
   try {
-    if (!provider) {
-      return { success: false, message: "No provider configured", error: "Provider not found" };
-    }
-
-    if (!selectedProvider?.variables?.api_key) {
-      return { success: false, message: "API key not provided", error: "Missing API key" };
-    }
+    // Validate provider and API key configuration
+    const validationError = validateProviderConfig(provider, selectedProvider);
+    if (validationError) return validationError;
 
     // For AssemblyAI special handler, we can test by making a simple API call
-    if (provider.requiresSpecialHandler && provider.specialHandler === "assemblyai-diarization") {
+    if (provider!.requiresSpecialHandler && provider!.specialHandler === "assemblyai-diarization") {
       const apiKey = selectedProvider.variables?.API_KEY || selectedProvider.variables?.api_key;
       if (!apiKey) {
-        return { success: false, message: "API key not provided", error: "Missing API key" };
+        return { success: false, message: ErrorMessages.CONFIG_NO_API_KEY, error: "Missing API key" };
       }
 
       // Test AssemblyAI by checking the API with a simple request
       try {
-        const response = await tauriFetch("https://api.assemblyai.com/v2/transcript", {
-          method: "GET",
-          headers: {
-            Authorization: apiKey,
-          },
-        });
+        const response = await fetchWithTimeout(
+          tauriFetch,
+          "https://api.assemblyai.com/v2/transcript",
+          {
+            method: "GET",
+            headers: {
+              Authorization: apiKey,
+            },
+          }
+        );
 
         // 401 = invalid key, 200/other = valid key
         if (response.status === 401) {
           return {
             success: false,
-            message: "Invalid API key",
-            error: "AssemblyAI authentication failed",
+            message: ErrorMessages.AUTH_INVALID_KEY,
+            error: "AssemblyAI HTTP 401",
           };
         }
 
         // Any other response means the key is valid
         return {
           success: true,
-          message: "Connection verified",
+          message: ErrorMessages.SUCCESS_VERIFIED,
         };
       } catch (error) {
-        return {
-          success: false,
-          message: "Network error",
-          error: error instanceof Error ? error.message : "Connection failed",
-        };
+        return handleFetchError(error);
       }
     }
 
-    let curlJson;
+    // Parse curl template (skip variable validation for STT - only needs API key)
+    let curlJson: ParsedCurl;
     try {
-      curlJson = curl2Json(provider.curl);
+      curlJson = curl2Json(provider!.curl) as ParsedCurl;
     } catch (error) {
       return {
         success: false,
-        message: "Invalid provider configuration",
+        message: ErrorMessages.CONFIG_INVALID,
         error: error instanceof Error ? error.message : "Failed to parse curl",
       };
     }
 
-    // Build variable map
-    const allVariables: Record<string, string> = {
-      ...Object.fromEntries(
-        Object.entries(selectedProvider.variables).map(([key, value]) => [
-          key.toUpperCase(),
-          value,
-        ])
-      ),
-      LANGUAGE: "en",
-    };
+    // Build variable map for template replacement
+    const allVariables = buildVariableMap(selectedProvider, { LANGUAGE: "en" });
 
-    let url = deepVariableReplacer(curlJson.url || "", allVariables);
-    const headers = deepVariableReplacer(curlJson.header || {}, allVariables);
+    let url = deepVariableReplacer(curlJson.url || "", allVariables) as string;
+    const headers = deepVariableReplacer(curlJson.header || {}, allVariables) as Record<string, string>;
 
     // For OpenAI/Groq Whisper style APIs, we can test with a tiny valid WAV file
     // This is a minimal valid WAV header (44 bytes) with no audio data
@@ -299,8 +438,8 @@ export async function testSTTProvider(
       0x00, 0x00, 0x00, 0x00, // Data size (0)
     ]);
 
-    const isForm = provider.curl.includes("-F ") || provider.curl.includes("--form");
-    const isBinaryUpload = provider.curl.includes("--data-binary");
+    const isForm = provider!.curl.includes("-F ") || provider!.curl.includes("--form");
+    const isBinaryUpload = provider!.curl.includes("--data-binary");
 
     let body: FormData | Blob;
     let finalHeaders = { ...headers };
@@ -320,11 +459,13 @@ export async function testSTTProvider(
     } else if (isBinaryUpload) {
       body = new Blob([minimalWavHeader], { type: "audio/wav" });
     } else {
-      // For non-form APIs, we need to send audio as base64
-      // This minimal approach might not work for all providers
+      // For non-form/non-binary APIs (e.g., JSON body with base64 audio),
+      // we cannot reliably test without implementing provider-specific logic.
+      // Return false to avoid false positives with invalid API keys.
       return {
-        success: true,
-        message: "Configuration looks valid",
+        success: false,
+        message: ErrorMessages.CONFIG_UNSUPPORTED,
+        error: "Automatic verification is not supported for this provider's API format. Please verify your API key manually.",
       };
     }
 
@@ -336,7 +477,7 @@ export async function testSTTProvider(
         typeof value === "string" ? decodeURIComponent(value) : "",
       ])
     );
-    const replacedParams = deepVariableReplacer(decodedParams, allVariables);
+    const replacedParams = deepVariableReplacer(decodedParams, allVariables) as Record<string, string>;
     const queryString = new URLSearchParams(replacedParams).toString();
     if (queryString) {
       url += (url.includes("?") ? "&" : "?") + queryString;
@@ -344,28 +485,15 @@ export async function testSTTProvider(
 
     const fetchFunction = url?.includes("http") ? tauriFetch : fetch;
 
-    const response = await fetchFunction(url, {
+    const response = await fetchWithTimeout(fetchFunction, url, {
       method: curlJson.method || "POST",
       headers: finalHeaders,
       body,
     });
 
-    // Check response status
-    if (response.status === 401 || response.status === 403) {
-      return {
-        success: false,
-        message: "Invalid API key",
-        error: `Authentication failed (${response.status})`,
-      };
-    }
-
-    if (response.status === 429) {
-      // Rate limited but key is valid
-      return {
-        success: true,
-        message: "API key verified (rate limited)",
-      };
-    }
+    // Handle common response status codes (401/403/429)
+    const statusResult = await handleResponseStatus(response);
+    if (statusResult) return statusResult;
 
     // 400 Bad Request is expected for empty/minimal audio - key is valid
     if (response.status === 400) {
@@ -374,21 +502,21 @@ export async function testSTTProvider(
       if (errorText.toLowerCase().includes("api key") || errorText.toLowerCase().includes("unauthorized")) {
         return {
           success: false,
-          message: "Invalid API key",
+          message: ErrorMessages.AUTH_INVALID_KEY,
           error: errorText,
         };
       }
       // Otherwise, the key is valid but audio was rejected
       return {
         success: true,
-        message: "API key verified",
+        message: ErrorMessages.SUCCESS_KEY_VERIFIED,
       };
     }
 
     if (response.ok) {
       return {
         success: true,
-        message: "Connection verified",
+        message: ErrorMessages.SUCCESS_VERIFIED,
       };
     }
 
@@ -396,15 +524,10 @@ export async function testSTTProvider(
     const errorText = await response.text().catch(() => response.statusText);
     return {
       success: false,
-      message: `API error: ${response.status}`,
+      message: ErrorMessages.RESPONSE_API_ERROR(response.status),
       error: errorText,
     };
   } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    return {
-      success: false,
-      message: "Connection failed",
-      error: message,
-    };
+    return handleFetchError(error);
   }
 }

--- a/src/lib/functions/index.ts
+++ b/src/lib/functions/index.ts
@@ -9,3 +9,4 @@ export * from "./context-builder";
 export * from "./translation.function";
 export * from "./audio-buffer";
 export * from "./pitch-analysis";
+export * from "./api-test.function";

--- a/src/lib/storage/index.ts
+++ b/src/lib/storage/index.ts
@@ -8,3 +8,4 @@ export * from "./pricing.storage";
 export * from "./speaker-profiles.storage";
 export * from "./user-identity.storage";
 export * from "./verification.storage";
+export * from "./secure-provider-configs";

--- a/src/lib/storage/index.ts
+++ b/src/lib/storage/index.ts
@@ -7,3 +7,4 @@ export * from "./response-settings.storage";
 export * from "./pricing.storage";
 export * from "./speaker-profiles.storage";
 export * from "./user-identity.storage";
+export * from "./verification.storage";

--- a/src/lib/storage/pricing.storage.ts
+++ b/src/lib/storage/pricing.storage.ts
@@ -18,6 +18,12 @@ export const DEFAULT_PRICING: PricingConfig = {
     "*": { inputPer1k: 0.002, outputPer1k: 0.008 }, // Default for unknown OpenAI models
   },
   claude: {
+    // Exact model IDs used in API
+    "claude-3-5-sonnet-20241022": { inputPer1k: 0.003, outputPer1k: 0.015 },
+    "claude-3-opus-20240229": { inputPer1k: 0.015, outputPer1k: 0.075 },
+    "claude-3-sonnet-20240229": { inputPer1k: 0.003, outputPer1k: 0.015 },
+    "claude-3-haiku-20240307": { inputPer1k: 0.00025, outputPer1k: 0.00125 },
+    // Pattern matches for partial names
     "claude-3-5-sonnet": { inputPer1k: 0.003, outputPer1k: 0.015 },
     "claude-3-opus": { inputPer1k: 0.015, outputPer1k: 0.075 },
     "claude-3-sonnet": { inputPer1k: 0.003, outputPer1k: 0.015 },
@@ -53,17 +59,38 @@ export const DEFAULT_PRICING: PricingConfig = {
     "*": { inputPer1k: 0.0001, outputPer1k: 0.0001 },
   },
   mistral: {
+    // Exact model IDs with -latest suffix
+    "mistral-large-latest": { inputPer1k: 0.004, outputPer1k: 0.012 },
+    "mistral-medium-latest": { inputPer1k: 0.0027, outputPer1k: 0.0081 },
+    "mistral-small-latest": { inputPer1k: 0.001, outputPer1k: 0.003 },
+    // Mixtral MoE models
+    "open-mixtral-8x22b": { inputPer1k: 0.002, outputPer1k: 0.006 },
+    "open-mixtral-8x7b": { inputPer1k: 0.0007, outputPer1k: 0.0007 },
+    // Pattern matches for partial names
     "mistral-large": { inputPer1k: 0.004, outputPer1k: 0.012 },
     "mistral-medium": { inputPer1k: 0.0027, outputPer1k: 0.0081 },
     "mistral-small": { inputPer1k: 0.001, outputPer1k: 0.003 },
     "*": { inputPer1k: 0.0004, outputPer1k: 0.0012 },
   },
   perplexity: {
+    // Online models (with web search)
+    "llama-3.1-sonar-large-128k-online": { inputPer1k: 0.001, outputPer1k: 0.001 },
+    "llama-3.1-sonar-small-128k-online": { inputPer1k: 0.0002, outputPer1k: 0.0002 },
+    // Chat models (no web search)
+    "llama-3.1-sonar-large-128k-chat": { inputPer1k: 0.001, outputPer1k: 0.001 },
+    "llama-3.1-sonar-small-128k-chat": { inputPer1k: 0.0002, outputPer1k: 0.0002 },
+    // Pattern matches
     "llama-3.1-sonar-large": { inputPer1k: 0.001, outputPer1k: 0.001 },
     "llama-3.1-sonar-small": { inputPer1k: 0.0002, outputPer1k: 0.0002 },
     "*": { inputPer1k: 0.001, outputPer1k: 0.001 },
   },
   openrouter: {
+    // Popular models via OpenRouter (pricing varies, these are estimates)
+    "openai/gpt-4o": { inputPer1k: 0.0025, outputPer1k: 0.01 },
+    "anthropic/claude-3.5-sonnet": { inputPer1k: 0.003, outputPer1k: 0.015 },
+    "meta-llama/llama-3.1-70b-instruct": { inputPer1k: 0.00059, outputPer1k: 0.00079 },
+    "google/gemini-pro-1.5": { inputPer1k: 0.00125, outputPer1k: 0.005 },
+    "mistralai/mistral-large": { inputPer1k: 0.004, outputPer1k: 0.012 },
     // OpenRouter has variable pricing, use a reasonable default
     "*": { inputPer1k: 0.001, outputPer1k: 0.003 },
   },
@@ -81,6 +108,12 @@ export const DEFAULT_PRICING: PricingConfig = {
   },
   ollama: {
     // Ollama is free (runs locally)
+    "llama3.2": { inputPer1k: 0, outputPer1k: 0 },
+    "llama3.1": { inputPer1k: 0, outputPer1k: 0 },
+    "mistral": { inputPer1k: 0, outputPer1k: 0 },
+    "codellama": { inputPer1k: 0, outputPer1k: 0 },
+    "phi3": { inputPer1k: 0, outputPer1k: 0 },
+    "gemma2": { inputPer1k: 0, outputPer1k: 0 },
     "*": { inputPer1k: 0, outputPer1k: 0 },
   },
   // Default for unknown providers
@@ -94,19 +127,52 @@ export const DEFAULT_PRICING: PricingConfig = {
  * Prices are in USD per minute of audio.
  */
 export const DEFAULT_STT_PRICING: STTPricingConfig = {
-  openai: {
+  // OpenAI Whisper (via openai-whisper provider ID)
+  "openai-whisper": {
     "whisper-1": { perMinute: 0.006 },
     "gpt-4o-mini-transcribe": { perMinute: 0.003 }, // Cheaper than Whisper!
     "gpt-4o-transcribe": { perMinute: 0.006 },
     "*": { perMinute: 0.006 },
   },
+  // Legacy key for backwards compatibility
+  openai: {
+    "whisper-1": { perMinute: 0.006 },
+    "gpt-4o-mini-transcribe": { perMinute: 0.003 },
+    "gpt-4o-transcribe": { perMinute: 0.006 },
+    "*": { perMinute: 0.006 },
+  },
+  // Groq Whisper (very affordable!)
   groq: {
-    // Groq Whisper is much cheaper!
     "whisper-large-v3": { perMinute: 0.000111 },
     "whisper-large-v3-turbo": { perMinute: 0.00004 },
     "distil-whisper-large-v3-en": { perMinute: 0.00002 },
     "*": { perMinute: 0.0001 },
   },
+  // ElevenLabs STT
+  "elevenlabs-stt": {
+    "scribe_v1": { perMinute: 0.01 }, // Estimate
+    "*": { perMinute: 0.01 },
+  },
+  // Google Cloud Speech-to-Text
+  "google-stt": {
+    "default": { perMinute: 0.006 },
+    "latest_long": { perMinute: 0.006 },
+    "latest_short": { perMinute: 0.006 },
+    "*": { perMinute: 0.006 },
+  },
+  // Legacy key for backwards compatibility
+  google: {
+    "*": { perMinute: 0.006 },
+  },
+  // Deepgram STT
+  "deepgram-stt": {
+    "nova-2": { perMinute: 0.0043 },
+    "nova": { perMinute: 0.0043 },
+    "enhanced": { perMinute: 0.0145 },
+    "base": { perMinute: 0.0125 },
+    "*": { perMinute: 0.0043 },
+  },
+  // Legacy key for backwards compatibility
   deepgram: {
     "nova-2": { perMinute: 0.0043 },
     "nova": { perMinute: 0.0043 },
@@ -114,20 +180,43 @@ export const DEFAULT_STT_PRICING: STTPricingConfig = {
     "base": { perMinute: 0.0125 },
     "*": { perMinute: 0.0043 },
   },
+  // Azure Speech Services
+  "azure-stt": {
+    "default": { perMinute: 0.01 },
+    "*": { perMinute: 0.01 },
+  },
+  // Legacy key for backwards compatibility
+  azure: {
+    "*": { perMinute: 0.01 },
+  },
+  // Speechmatics STT
+  "speechmatics-stt": {
+    "default": { perMinute: 0.012 }, // ~$0.72/hour
+    "*": { perMinute: 0.012 },
+  },
+  // Rev.ai STT
+  "rev-ai-stt": {
+    "default": { perMinute: 0.02 }, // $0.02/min for async
+    "*": { perMinute: 0.02 },
+  },
+  // IBM Watson STT
+  "ibm-watson-stt": {
+    "default": { perMinute: 0.02 }, // ~$0.02/min
+    "*": { perMinute: 0.02 },
+  },
+  // AssemblyAI (with diarization)
+  "assemblyai-diarization": {
+    "best": { perMinute: 0.00617 },
+    "nano": { perMinute: 0.002 },
+    "*": { perMinute: 0.00617 },
+  },
+  // Legacy key for backwards compatibility
   assemblyai: {
     "best": { perMinute: 0.00617 },
     "nano": { perMinute: 0.002 },
     "universal": { perMinute: 0.0025 },
-    "universal-diarization": { perMinute: 0.00283 }, // Universal + speaker labels ($0.00033 extra)
-    "*": { perMinute: 0.00283 }, // Default assumes diarization enabled
-  },
-  google: {
-    // Google Cloud Speech-to-Text
-    "*": { perMinute: 0.006 },
-  },
-  azure: {
-    // Azure Speech Services
-    "*": { perMinute: 0.01 },
+    "universal-diarization": { perMinute: 0.00283 },
+    "*": { perMinute: 0.00283 },
   },
   // Default for unknown STT providers
   "*": {

--- a/src/lib/storage/secure-provider-configs.ts
+++ b/src/lib/storage/secure-provider-configs.ts
@@ -152,35 +152,45 @@ export function getCachedSTTConfig(providerId: string): Record<string, string> |
 }
 
 /**
- * Update cache synchronously (for use in state setters)
- * The actual save to secure storage happens asynchronously
+ * Update AI config cache and persist to secure storage
+ * Returns a Promise that resolves when the save is complete
  */
-export function updateAIConfigCache(providerId: string, variables: Record<string, string>): void {
+export async function updateAIConfigCache(
+  providerId: string,
+  variables: Record<string, string>
+): Promise<void> {
   if (aiConfigsCache === null) {
     aiConfigsCache = {};
   }
   aiConfigsCache[providerId] = variables;
 
-  // Fire-and-forget async save
-  secureSet(AI_CONFIGS_KEY, JSON.stringify(aiConfigsCache)).catch((error) => {
+  try {
+    await secureSet(AI_CONFIGS_KEY, JSON.stringify(aiConfigsCache));
+  } catch (error) {
     console.error("[SecureStorage] Failed to persist AI config:", error);
-  });
+    throw error;
+  }
 }
 
 /**
- * Update cache synchronously (for use in state setters)
- * The actual save to secure storage happens asynchronously
+ * Update STT config cache and persist to secure storage
+ * Returns a Promise that resolves when the save is complete
  */
-export function updateSTTConfigCache(providerId: string, variables: Record<string, string>): void {
+export async function updateSTTConfigCache(
+  providerId: string,
+  variables: Record<string, string>
+): Promise<void> {
   if (sttConfigsCache === null) {
     sttConfigsCache = {};
   }
   sttConfigsCache[providerId] = variables;
 
-  // Fire-and-forget async save
-  secureSet(STT_CONFIGS_KEY, JSON.stringify(sttConfigsCache)).catch((error) => {
+  try {
+    await secureSet(STT_CONFIGS_KEY, JSON.stringify(sttConfigsCache));
+  } catch (error) {
     console.error("[SecureStorage] Failed to persist STT config:", error);
-  });
+    throw error;
+  }
 }
 
 /**

--- a/src/lib/storage/secure-provider-configs.ts
+++ b/src/lib/storage/secure-provider-configs.ts
@@ -1,0 +1,235 @@
+/**
+ * Secure Provider Configuration Storage
+ *
+ * Stores API keys and other sensitive provider configuration using Tauri's
+ * encrypted store plugin instead of plain localStorage.
+ *
+ * Security Benefits:
+ * - Data is encrypted at rest
+ * - Protected from malicious browser extensions
+ * - Protected from XSS attacks that read localStorage
+ * - Uses OS-level security features
+ */
+
+import { secureSet, secureGet, secureDelete } from "@/lib/secure-storage";
+
+// Storage keys for provider configs
+const AI_CONFIGS_KEY = "secure_ai_provider_configs";
+const STT_CONFIGS_KEY = "secure_stt_provider_configs";
+
+// Cache for loaded configs to avoid async reads on every access
+let aiConfigsCache: Record<string, Record<string, string>> | null = null;
+let sttConfigsCache: Record<string, Record<string, string>> | null = null;
+
+// Loading promises to avoid race conditions
+let aiLoadingPromise: Promise<void> | null = null;
+let sttLoadingPromise: Promise<void> | null = null;
+
+/**
+ * Load AI provider configs from secure storage into cache
+ */
+export async function loadSecureAIConfigs(): Promise<Record<string, Record<string, string>>> {
+  if (aiConfigsCache !== null) {
+    return aiConfigsCache;
+  }
+
+  // Avoid duplicate loading
+  if (aiLoadingPromise) {
+    await aiLoadingPromise;
+    return aiConfigsCache || {};
+  }
+
+  aiLoadingPromise = (async () => {
+    try {
+      const stored = await secureGet(AI_CONFIGS_KEY);
+      if (stored) {
+        aiConfigsCache = JSON.parse(stored);
+      } else {
+        aiConfigsCache = {};
+      }
+    } catch (error) {
+      console.error("[SecureStorage] Failed to load AI configs:", error);
+      aiConfigsCache = {};
+    }
+  })();
+
+  await aiLoadingPromise;
+  aiLoadingPromise = null;
+  return aiConfigsCache || {};
+}
+
+/**
+ * Load STT provider configs from secure storage into cache
+ */
+export async function loadSecureSTTConfigs(): Promise<Record<string, Record<string, string>>> {
+  if (sttConfigsCache !== null) {
+    return sttConfigsCache;
+  }
+
+  // Avoid duplicate loading
+  if (sttLoadingPromise) {
+    await sttLoadingPromise;
+    return sttConfigsCache || {};
+  }
+
+  sttLoadingPromise = (async () => {
+    try {
+      const stored = await secureGet(STT_CONFIGS_KEY);
+      if (stored) {
+        sttConfigsCache = JSON.parse(stored);
+      } else {
+        sttConfigsCache = {};
+      }
+    } catch (error) {
+      console.error("[SecureStorage] Failed to load STT configs:", error);
+      sttConfigsCache = {};
+    }
+  })();
+
+  await sttLoadingPromise;
+  sttLoadingPromise = null;
+  return sttConfigsCache || {};
+}
+
+/**
+ * Save AI provider config to secure storage
+ * Updates both cache and persistent storage
+ */
+export async function saveSecureAIConfig(
+  providerId: string,
+  variables: Record<string, string>
+): Promise<void> {
+  // Ensure cache is loaded
+  const configs = await loadSecureAIConfigs();
+
+  // Update cache
+  configs[providerId] = variables;
+  aiConfigsCache = configs;
+
+  // Persist to secure storage
+  try {
+    await secureSet(AI_CONFIGS_KEY, JSON.stringify(configs));
+  } catch (error) {
+    console.error("[SecureStorage] Failed to save AI config:", error);
+  }
+}
+
+/**
+ * Save STT provider config to secure storage
+ * Updates both cache and persistent storage
+ */
+export async function saveSecureSTTConfig(
+  providerId: string,
+  variables: Record<string, string>
+): Promise<void> {
+  // Ensure cache is loaded
+  const configs = await loadSecureSTTConfigs();
+
+  // Update cache
+  configs[providerId] = variables;
+  sttConfigsCache = configs;
+
+  // Persist to secure storage
+  try {
+    await secureSet(STT_CONFIGS_KEY, JSON.stringify(configs));
+  } catch (error) {
+    console.error("[SecureStorage] Failed to save STT config:", error);
+  }
+}
+
+/**
+ * Get cached AI config for a provider (sync, must call loadSecureAIConfigs first)
+ */
+export function getCachedAIConfig(providerId: string): Record<string, string> | undefined {
+  return aiConfigsCache?.[providerId];
+}
+
+/**
+ * Get cached STT config for a provider (sync, must call loadSecureSTTConfigs first)
+ */
+export function getCachedSTTConfig(providerId: string): Record<string, string> | undefined {
+  return sttConfigsCache?.[providerId];
+}
+
+/**
+ * Update cache synchronously (for use in state setters)
+ * The actual save to secure storage happens asynchronously
+ */
+export function updateAIConfigCache(providerId: string, variables: Record<string, string>): void {
+  if (aiConfigsCache === null) {
+    aiConfigsCache = {};
+  }
+  aiConfigsCache[providerId] = variables;
+
+  // Fire-and-forget async save
+  secureSet(AI_CONFIGS_KEY, JSON.stringify(aiConfigsCache)).catch((error) => {
+    console.error("[SecureStorage] Failed to persist AI config:", error);
+  });
+}
+
+/**
+ * Update cache synchronously (for use in state setters)
+ * The actual save to secure storage happens asynchronously
+ */
+export function updateSTTConfigCache(providerId: string, variables: Record<string, string>): void {
+  if (sttConfigsCache === null) {
+    sttConfigsCache = {};
+  }
+  sttConfigsCache[providerId] = variables;
+
+  // Fire-and-forget async save
+  secureSet(STT_CONFIGS_KEY, JSON.stringify(sttConfigsCache)).catch((error) => {
+    console.error("[SecureStorage] Failed to persist STT config:", error);
+  });
+}
+
+/**
+ * Clear all secure provider configs (for testing/reset)
+ */
+export async function clearSecureProviderConfigs(): Promise<void> {
+  aiConfigsCache = null;
+  sttConfigsCache = null;
+  await Promise.all([
+    secureDelete(AI_CONFIGS_KEY),
+    secureDelete(STT_CONFIGS_KEY),
+  ]);
+}
+
+/**
+ * Migrate existing localStorage configs to secure storage
+ * Call this once on app startup to move existing data
+ */
+export async function migrateProviderConfigsToSecureStorage(): Promise<void> {
+  const AI_PROVIDER_CONFIGS_KEY = "ai_provider_configs";
+  const STT_PROVIDER_CONFIGS_KEY = "stt_provider_configs";
+
+  try {
+    // Migrate AI configs
+    const aiConfigsLocal = localStorage.getItem(AI_PROVIDER_CONFIGS_KEY);
+    if (aiConfigsLocal) {
+      const existingSecure = await secureGet(AI_CONFIGS_KEY);
+      if (!existingSecure) {
+        // Only migrate if secure storage is empty
+        await secureSet(AI_CONFIGS_KEY, aiConfigsLocal);
+        console.log("[SecureStorage] Migrated AI provider configs to secure storage");
+      }
+      // Remove from localStorage after successful migration
+      localStorage.removeItem(AI_PROVIDER_CONFIGS_KEY);
+    }
+
+    // Migrate STT configs
+    const sttConfigsLocal = localStorage.getItem(STT_PROVIDER_CONFIGS_KEY);
+    if (sttConfigsLocal) {
+      const existingSecure = await secureGet(STT_CONFIGS_KEY);
+      if (!existingSecure) {
+        // Only migrate if secure storage is empty
+        await secureSet(STT_CONFIGS_KEY, sttConfigsLocal);
+        console.log("[SecureStorage] Migrated STT provider configs to secure storage");
+      }
+      // Remove from localStorage after successful migration
+      localStorage.removeItem(STT_PROVIDER_CONFIGS_KEY);
+    }
+  } catch (error) {
+    console.error("[SecureStorage] Migration failed:", error);
+  }
+}

--- a/src/lib/storage/verification.storage.ts
+++ b/src/lib/storage/verification.storage.ts
@@ -54,9 +54,13 @@ export function isVerificationCacheLoaded(): boolean {
 /**
  * Creates a secure SHA-256 hash of the API key for change detection.
  * Uses Web Crypto API for cryptographically secure hashing.
+ *
+ * @throws Error if API key is empty or whitespace-only
  */
 async function hashApiKey(apiKey: string): Promise<string> {
-  if (!apiKey) return "";
+  if (!apiKey || apiKey.trim() === "") {
+    throw new Error("API key cannot be empty");
+  }
 
   const encoder = new TextEncoder();
   const data = encoder.encode(apiKey);

--- a/src/lib/storage/verification.storage.ts
+++ b/src/lib/storage/verification.storage.ts
@@ -1,0 +1,171 @@
+/**
+ * Verification Storage
+ *
+ * Stores and retrieves API verification status for AI and STT providers.
+ * Verification is invalidated when the provider, model, or API key changes.
+ */
+
+import { STORAGE_KEYS } from "@/config/constants";
+
+interface VerificationData {
+  /** Provider ID */
+  provider: string;
+  /** Model name (for detecting changes) */
+  model: string;
+  /** Hash of the API key (to detect changes without storing the key) */
+  apiKeyHash: string;
+  /** When the verification was performed */
+  verifiedAt: number;
+  /** Whether verification was successful */
+  isVerified: boolean;
+  /** Optional error message if verification failed */
+  errorMessage?: string;
+}
+
+/**
+ * Creates a simple hash of the API key for change detection.
+ * This is not for security - just to detect if the key changed.
+ */
+function hashApiKey(apiKey: string): string {
+  if (!apiKey) return "";
+  // Simple hash: length + first 4 chars + last 4 chars
+  const first = apiKey.substring(0, 4);
+  const last = apiKey.substring(apiKey.length - 4);
+  return `${apiKey.length}:${first}...${last}`;
+}
+
+/**
+ * Gets the AI provider verification status from localStorage.
+ */
+export function getAIVerificationStatus(): VerificationData | null {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEYS.AI_PROVIDER_VERIFIED);
+    if (!stored) return null;
+    return JSON.parse(stored);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Gets the STT provider verification status from localStorage.
+ */
+export function getSTTVerificationStatus(): VerificationData | null {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEYS.STT_PROVIDER_VERIFIED);
+    if (!stored) return null;
+    return JSON.parse(stored);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Saves AI provider verification status to localStorage.
+ */
+export function setAIVerificationStatus(
+  provider: string,
+  model: string,
+  apiKey: string,
+  isVerified: boolean,
+  errorMessage?: string
+): void {
+  const data: VerificationData = {
+    provider,
+    model,
+    apiKeyHash: hashApiKey(apiKey),
+    verifiedAt: Date.now(),
+    isVerified,
+    errorMessage,
+  };
+  localStorage.setItem(STORAGE_KEYS.AI_PROVIDER_VERIFIED, JSON.stringify(data));
+}
+
+/**
+ * Saves STT provider verification status to localStorage.
+ */
+export function setSTTVerificationStatus(
+  provider: string,
+  model: string,
+  apiKey: string,
+  isVerified: boolean,
+  errorMessage?: string
+): void {
+  const data: VerificationData = {
+    provider,
+    model,
+    apiKeyHash: hashApiKey(apiKey),
+    verifiedAt: Date.now(),
+    isVerified,
+    errorMessage,
+  };
+  localStorage.setItem(STORAGE_KEYS.STT_PROVIDER_VERIFIED, JSON.stringify(data));
+}
+
+/**
+ * Clears AI provider verification status.
+ */
+export function clearAIVerificationStatus(): void {
+  localStorage.removeItem(STORAGE_KEYS.AI_PROVIDER_VERIFIED);
+}
+
+/**
+ * Clears STT provider verification status.
+ */
+export function clearSTTVerificationStatus(): void {
+  localStorage.removeItem(STORAGE_KEYS.STT_PROVIDER_VERIFIED);
+}
+
+/**
+ * Checks if the AI provider verification is still valid.
+ * Invalidates if provider, model, or API key has changed.
+ */
+export function isAIVerificationValid(
+  provider: string,
+  model: string,
+  apiKey: string
+): boolean {
+  const status = getAIVerificationStatus();
+  if (!status) return false;
+  if (!status.isVerified) return false;
+  if (status.provider !== provider) return false;
+  if (status.model !== model) return false;
+  if (status.apiKeyHash !== hashApiKey(apiKey)) return false;
+
+  return true;
+}
+
+/**
+ * Checks if the STT provider verification is still valid.
+ * Invalidates if provider, model, or API key has changed.
+ */
+export function isSTTVerificationValid(
+  provider: string,
+  model: string,
+  apiKey: string
+): boolean {
+  const status = getSTTVerificationStatus();
+  if (!status) return false;
+  if (!status.isVerified) return false;
+  if (status.provider !== provider) return false;
+  if (status.model !== model) return false;
+  if (status.apiKeyHash !== hashApiKey(apiKey)) return false;
+
+  return true;
+}
+
+/**
+ * Gets the verification error message for AI provider if verification failed.
+ */
+export function getAIVerificationError(): string | undefined {
+  const status = getAIVerificationStatus();
+  return status?.errorMessage;
+}
+
+/**
+ * Gets the verification error message for STT provider if verification failed.
+ */
+export function getSTTVerificationError(): string | undefined {
+  const status = getSTTVerificationStatus();
+  return status?.errorMessage;
+}

--- a/src/pages/app/index.tsx
+++ b/src/pages/app/index.tsx
@@ -5,16 +5,18 @@ import {
   AudioVisualizer,
   StatusIndicator,
 } from "./components";
-import { useApp } from "@/hooks";
+import { useApp, useSetupStatus } from "@/hooks";
 import { useApp as useAppContext } from "@/contexts";
 import { invoke } from "@tauri-apps/api/core";
 import { ErrorBoundary } from "react-error-boundary";
 import { ErrorLayout } from "@/layouts";
 import { getPlatform } from "@/lib";
+import { AlertCircle } from "lucide-react";
 
 const App = () => {
   const { isHidden, systemAudio } = useApp();
   const { customizable } = useAppContext();
+  const { isComplete: setupComplete, aiConfigured, sttConfigured } = useSetupStatus();
   const platform = getPlatform();
 
   const openDashboard = async () => {
@@ -41,44 +43,78 @@ const App = () => {
         }`}
       >
         <Card className="w-full flex flex-row items-center gap-2 p-2">
-          <SystemAudio {...systemAudio} />
-          {systemAudio?.capturing ? (
-            <div className="flex flex-row items-center gap-2 justify-between w-full">
-              <div className="flex flex-1 items-center gap-2">
-                <AudioVisualizer
-                  stream={systemAudio?.stream}
-                  isRecording={systemAudio?.capturing}
-                />
+          {/* Setup Required Message */}
+          {!setupComplete && (
+            <div className="flex flex-1 items-center gap-3 px-2">
+              <AlertCircle className="h-5 w-5 text-yellow-500 flex-shrink-0" />
+              <div className="flex flex-col min-w-0">
+                <span className="text-sm font-medium text-foreground">
+                  Setup Required
+                </span>
+                <span className="text-xs text-muted-foreground truncate">
+                  {!aiConfigured && !sttConfigured
+                    ? "Configure & verify AI + Speech providers"
+                    : !aiConfigured
+                    ? "Configure & verify AI provider"
+                    : !sttConfigured
+                    ? "Configure & verify Speech-to-Text"
+                    : "Verify your API connections"}
+                </span>
               </div>
-              <div className="flex !w-fit items-center gap-2">
-                <StatusIndicator
-                  setupRequired={systemAudio.setupRequired}
-                  error={systemAudio.error}
-                  isProcessing={systemAudio.isProcessing}
-                  isAIProcessing={systemAudio.isAIProcessing}
-                  capturing={systemAudio.capturing}
-                />
-              </div>
+              <Button
+                size="sm"
+                variant="outline"
+                className="ml-auto flex-shrink-0"
+                onClick={openDashboard}
+              >
+                Open Setup
+              </Button>
             </div>
-          ) : null}
+          )}
 
-          <div
-            className={`${
-              systemAudio?.capturing
-                ? "hidden w-full fade-out transition-all duration-300"
-                : "w-full flex flex-row gap-2 items-center"
-            }`}
-          >
-            <Completion isHidden={isHidden} />
-            <Button
-              size={"icon"}
-              className="cursor-pointer"
-              title="Open Dev Space"
-              onClick={openDashboard}
-            >
-              <WingIcon className="h-4 w-4" />
-            </Button>
-          </div>
+          {/* Normal UI when setup is complete */}
+          {setupComplete && (
+            <>
+              <SystemAudio {...systemAudio} />
+              {systemAudio?.capturing ? (
+                <div className="flex flex-row items-center gap-2 justify-between w-full">
+                  <div className="flex flex-1 items-center gap-2">
+                    <AudioVisualizer
+                      stream={systemAudio?.stream}
+                      isRecording={systemAudio?.capturing}
+                    />
+                  </div>
+                  <div className="flex !w-fit items-center gap-2">
+                    <StatusIndicator
+                      setupRequired={systemAudio.setupRequired}
+                      error={systemAudio.error}
+                      isProcessing={systemAudio.isProcessing}
+                      isAIProcessing={systemAudio.isAIProcessing}
+                      capturing={systemAudio.capturing}
+                    />
+                  </div>
+                </div>
+              ) : null}
+
+              <div
+                className={`${
+                  systemAudio?.capturing
+                    ? "hidden w-full fade-out transition-all duration-300"
+                    : "w-full flex flex-row gap-2 items-center"
+                }`}
+              >
+                <Completion isHidden={isHidden} />
+                <Button
+                  size={"icon"}
+                  className="cursor-pointer"
+                  title="Open Settings"
+                  onClick={openDashboard}
+                >
+                  <WingIcon className="h-4 w-4" />
+                </Button>
+              </div>
+            </>
+          )}
 
           <Updater />
           <DragButton />

--- a/src/pages/dev/components/SetupProgressHeader.tsx
+++ b/src/pages/dev/components/SetupProgressHeader.tsx
@@ -2,6 +2,13 @@ import { useSetupStatus } from "@/hooks";
 import { CheckCircle2, AlertCircle, Circle } from "lucide-react";
 import { cn } from "@/lib/utils";
 
+// StatusIcon component defined outside to prevent recreation on every render
+const StatusIcon = ({ done, pending }: { done: boolean; pending?: boolean }) => {
+  if (done) return <CheckCircle2 className="size-4 text-green-500 flex-shrink-0" />;
+  if (pending) return <Circle className="size-4 text-muted-foreground/50 flex-shrink-0" />;
+  return <AlertCircle className="size-4 text-yellow-500 flex-shrink-0" />;
+};
+
 export const SetupProgressHeader = () => {
   const {
     isComplete,
@@ -13,12 +20,6 @@ export const SetupProgressHeader = () => {
     sttDetails,
     completionPercent,
   } = useSetupStatus();
-
-  const StatusIcon = ({ done, pending }: { done: boolean; pending?: boolean }) => {
-    if (done) return <CheckCircle2 className="size-4 text-green-500 flex-shrink-0" />;
-    if (pending) return <Circle className="size-4 text-muted-foreground/50 flex-shrink-0" />;
-    return <AlertCircle className="size-4 text-yellow-500 flex-shrink-0" />;
-  };
 
   return (
     <div className="rounded-lg border border-border bg-card p-4 mb-6">

--- a/src/pages/dev/components/SetupProgressHeader.tsx
+++ b/src/pages/dev/components/SetupProgressHeader.tsx
@@ -1,0 +1,132 @@
+import { useSetupStatus } from "@/hooks";
+import { CheckCircle2, AlertCircle, Circle } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+export const SetupProgressHeader = () => {
+  const {
+    isComplete,
+    aiConfigured,
+    sttConfigured,
+    aiVerified,
+    sttVerified,
+    aiDetails,
+    sttDetails,
+    completionPercent,
+  } = useSetupStatus();
+
+  const StatusIcon = ({ done, pending }: { done: boolean; pending?: boolean }) => {
+    if (done) return <CheckCircle2 className="size-4 text-green-500 flex-shrink-0" />;
+    if (pending) return <Circle className="size-4 text-muted-foreground/50 flex-shrink-0" />;
+    return <AlertCircle className="size-4 text-yellow-500 flex-shrink-0" />;
+  };
+
+  return (
+    <div className="rounded-lg border border-border bg-card p-4 mb-6">
+      {/* Header */}
+      <div className="flex items-center justify-between mb-3">
+        <h2 className="text-sm font-semibold text-foreground">Setup Progress</h2>
+        <span
+          className={cn(
+            "text-xs font-medium px-2 py-0.5 rounded-full",
+            isComplete
+              ? "bg-green-500/10 text-green-600 dark:text-green-400"
+              : "bg-yellow-500/10 text-yellow-600 dark:text-yellow-400"
+          )}
+        >
+          {isComplete ? "Complete" : `${Math.round(completionPercent)}% Done`}
+        </span>
+      </div>
+
+      {/* Progress Bar */}
+      <div className="h-2 bg-muted rounded-full overflow-hidden mb-4">
+        <div
+          className={cn(
+            "h-full transition-all duration-500 rounded-full",
+            isComplete ? "bg-green-500" : "bg-yellow-500"
+          )}
+          style={{ width: `${completionPercent}%` }}
+        />
+      </div>
+
+      {/* Status Items - 4 steps now */}
+      <div className="space-y-2">
+        {/* AI Provider Configured */}
+        <div className="flex items-center gap-2">
+          <StatusIcon done={aiConfigured} />
+          <span className="text-sm text-foreground">
+            {aiConfigured ? (
+              <>
+                AI Provider configured
+                <span className="text-muted-foreground ml-1">
+                  ({aiDetails.providerName}
+                  {aiDetails.modelName && ` - ${aiDetails.modelName}`})
+                </span>
+              </>
+            ) : (
+              <span className="text-muted-foreground">Configure AI Provider</span>
+            )}
+          </span>
+        </div>
+
+        {/* AI Provider Verified */}
+        <div className="flex items-center gap-2 pl-6">
+          <StatusIcon done={aiVerified} pending={!aiConfigured} />
+          <span className={cn("text-sm", !aiConfigured && "text-muted-foreground/50")}>
+            {aiVerified ? (
+              <span className="text-foreground">AI connection verified</span>
+            ) : aiConfigured ? (
+              <span className="text-muted-foreground">Verify AI connection</span>
+            ) : (
+              <span className="text-muted-foreground/50">Verify AI connection</span>
+            )}
+          </span>
+        </div>
+
+        {/* STT Provider Configured */}
+        <div className="flex items-center gap-2">
+          <StatusIcon done={sttConfigured} />
+          <span className="text-sm text-foreground">
+            {sttConfigured ? (
+              <>
+                Speech-to-Text configured
+                <span className="text-muted-foreground ml-1">
+                  ({sttDetails.providerName}
+                  {sttDetails.modelName && ` - ${sttDetails.modelName}`})
+                </span>
+              </>
+            ) : (
+              <span className="text-muted-foreground">Configure Speech-to-Text</span>
+            )}
+          </span>
+        </div>
+
+        {/* STT Provider Verified */}
+        <div className="flex items-center gap-2 pl-6">
+          <StatusIcon done={sttVerified} pending={!sttConfigured} />
+          <span className={cn("text-sm", !sttConfigured && "text-muted-foreground/50")}>
+            {sttVerified ? (
+              <span className="text-foreground">Speech-to-Text verified</span>
+            ) : sttConfigured ? (
+              <span className="text-muted-foreground">Verify Speech-to-Text connection</span>
+            ) : (
+              <span className="text-muted-foreground/50">Verify Speech-to-Text connection</span>
+            )}
+          </span>
+        </div>
+      </div>
+
+      {/* Help Text */}
+      {!isComplete && (
+        <p className="text-xs text-muted-foreground mt-4 pt-3 border-t border-border">
+          {!aiConfigured || !sttConfigured ? (
+            "Configure both providers below, then verify each connection to unlock Meetwings."
+          ) : !aiVerified || !sttVerified ? (
+            "Check the verification box below each provider to test your API keys."
+          ) : (
+            "All set! You can now use Meetwings."
+          )}
+        </p>
+      )}
+    </div>
+  );
+};

--- a/src/pages/dev/components/ai-configs/Providers.tsx
+++ b/src/pages/dev/components/ai-configs/Providers.tsx
@@ -1,8 +1,10 @@
-import { Button, Header, Input, Selection, TextInput } from "@/components";
+import { Button, Header, Input, Selection, TextInput, ModelSelector } from "@/components";
 import { UseSettingsReturn } from "@/types";
 import curl2Json, { ResultJSON } from "@bany/curl-to-json";
-import { KeyIcon, TrashIcon } from "lucide-react";
+import { KeyIcon, TrashIcon, ExternalLink } from "lucide-react";
 import { useEffect, useState } from "react";
+import { getAIProviderInfo } from "@/config/models.constants";
+import { openUrl } from "@tauri-apps/plugin-opener";
 
 export const Providers = ({
   allAiProviders,
@@ -76,6 +78,32 @@ export const Providers = ({
           description={`If you want to use different url or method, you can always create a custom provider.`}
         />
       ) : null}
+
+      {/* Provider signup/pricing links */}
+      {selectedAIProvider?.provider && !allAiProviders?.find(p => p?.id === selectedAIProvider?.provider)?.isCustom && (() => {
+        const providerInfo = getAIProviderInfo(selectedAIProvider.provider);
+        if (!providerInfo) return null;
+        return (
+          <div className="flex flex-wrap gap-2 py-2">
+            <button
+              onClick={() => openUrl(providerInfo.signupUrl)}
+              className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm bg-primary/10 hover:bg-primary/20 text-primary rounded-md transition-colors"
+            >
+              <ExternalLink className="h-3.5 w-3.5" />
+              Get API Key from {providerInfo.name}
+            </button>
+            {providerInfo.pricingUrl && (
+              <button
+                onClick={() => openUrl(providerInfo.pricingUrl!)}
+                className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm bg-secondary hover:bg-secondary/80 text-secondary-foreground rounded-md transition-colors"
+              >
+                <ExternalLink className="h-3.5 w-3.5" />
+                View Pricing
+              </button>
+            )}
+          </div>
+        );
+      })()}
 
       {findKeyAndValue("api_key") ? (
         <div className="space-y-2">
@@ -184,6 +212,39 @@ export const Providers = ({
               return selectedAIProvider.variables[variable.key] || "";
             };
 
+            const isModelVariable = variable?.key === "model";
+            const currentProvider = allAiProviders?.find(
+              (p) => p?.id === selectedAIProvider?.provider
+            );
+            const isCustomProvider = currentProvider?.isCustom;
+            const providerDisplayName = isCustomProvider
+              ? "Custom Provider"
+              : selectedAIProvider?.provider;
+
+            // Use ModelSelector for model variable if provider has predefined models
+            if (isModelVariable && !isCustomProvider && selectedAIProvider?.provider) {
+              return (
+                <div key={variable?.key}>
+                  <ModelSelector
+                    providerId={selectedAIProvider.provider}
+                    selectedModel={getVariableValue()}
+                    onModelChange={(model) => {
+                      if (!variable?.key || !selectedAIProvider) return;
+                      onSetSelectedAIProvider({
+                        ...selectedAIProvider,
+                        variables: {
+                          ...selectedAIProvider.variables,
+                          [variable.key]: model,
+                        },
+                      });
+                    }}
+                    type="ai"
+                    providerDisplayName={providerDisplayName}
+                  />
+                </div>
+              );
+            }
+
             return (
               <div className="space-y-1" key={variable?.key}>
                 <Header
@@ -191,22 +252,10 @@ export const Providers = ({
                   description={`add your preferred ${variable?.key?.replace(
                     /_/g,
                     " "
-                  )} for ${
-                    allAiProviders?.find(
-                      (p) => p?.id === selectedAIProvider?.provider
-                    )?.isCustom
-                      ? "Custom Provider"
-                      : selectedAIProvider?.provider
-                  }`}
+                  )} for ${providerDisplayName}`}
                 />
                 <TextInput
-                  placeholder={`Enter ${
-                    allAiProviders?.find(
-                      (p) => p?.id === selectedAIProvider?.provider
-                    )?.isCustom
-                      ? "Custom Provider"
-                      : selectedAIProvider?.provider
-                  } ${variable?.key?.replace(/_/g, " ") || "value"}`}
+                  placeholder={`Enter ${providerDisplayName} ${variable?.key?.replace(/_/g, " ") || "value"}`}
                   value={getVariableValue()}
                   onChange={(value) => {
                     if (!variable?.key || !selectedAIProvider) return;

--- a/src/pages/dev/components/ai-configs/Providers.tsx
+++ b/src/pages/dev/components/ai-configs/Providers.tsx
@@ -5,6 +5,18 @@ import { KeyIcon, TrashIcon, ExternalLink } from "lucide-react";
 import { useEffect, useState } from "react";
 import { getAIProviderInfo } from "@/config/models.constants";
 import { openUrl } from "@tauri-apps/plugin-opener";
+import { toast } from "sonner";
+
+const handleOpenUrl = async (url: string) => {
+  try {
+    await openUrl(url);
+  } catch (error) {
+    console.error("Failed to open URL:", error);
+    toast.error("Failed to open link", {
+      description: "Please try again or copy the URL manually.",
+    });
+  }
+};
 
 export const Providers = ({
   allAiProviders,
@@ -83,18 +95,19 @@ export const Providers = ({
       {selectedAIProvider?.provider && !allAiProviders?.find(p => p?.id === selectedAIProvider?.provider)?.isCustom && (() => {
         const providerInfo = getAIProviderInfo(selectedAIProvider.provider);
         if (!providerInfo) return null;
+        const { pricingUrl } = providerInfo;
         return (
           <div className="flex flex-wrap gap-2 py-2">
             <button
-              onClick={() => openUrl(providerInfo.signupUrl)}
+              onClick={() => handleOpenUrl(providerInfo.signupUrl)}
               className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm bg-primary/10 hover:bg-primary/20 text-primary rounded-md transition-colors"
             >
               <ExternalLink className="h-3.5 w-3.5" />
               Get API Key from {providerInfo.name}
             </button>
-            {providerInfo.pricingUrl && (
+            {pricingUrl && (
               <button
-                onClick={() => openUrl(providerInfo.pricingUrl!)}
+                onClick={() => handleOpenUrl(pricingUrl)}
                 className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm bg-secondary hover:bg-secondary/80 text-secondary-foreground rounded-md transition-colors"
               >
                 <ExternalLink className="h-3.5 w-3.5" />

--- a/src/pages/dev/components/ai-configs/Providers.tsx
+++ b/src/pages/dev/components/ai-configs/Providers.tsx
@@ -1,8 +1,8 @@
-import { Button, Header, Input, Selection, TextInput, ModelSelector } from "@/components";
-import { UseSettingsReturn } from "@/types";
+import { Button, Header, Input, Selection, TextInput, ModelSelector, ProviderVerification } from "@/components";
+import { UseSettingsReturn, TYPE_PROVIDER } from "@/types";
 import curl2Json, { ResultJSON } from "@bany/curl-to-json";
 import { KeyIcon, TrashIcon, ExternalLink } from "lucide-react";
-import { useEffect, useState } from "react";
+import { useEffect, useState, useCallback } from "react";
 import { getAIProviderInfo } from "@/config/models.constants";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import { toast } from "sonner";
@@ -26,6 +26,17 @@ export const Providers = ({
 }: UseSettingsReturn) => {
   const [localSelectedProvider, setLocalSelectedProvider] =
     useState<ResultJSON | null>(null);
+  const [, forceUpdate] = useState({});
+
+  // Get the current provider object
+  const currentProvider = allAiProviders?.find(
+    (p: TYPE_PROVIDER) => p?.id === selectedAIProvider?.provider
+  ) as TYPE_PROVIDER | undefined;
+
+  // Force re-render when verification changes to update parent state
+  const handleVerificationChange = useCallback(() => {
+    forceUpdate({});
+  }, []);
 
   useEffect(() => {
     if (selectedAIProvider?.provider) {
@@ -286,6 +297,17 @@ export const Providers = ({
             );
           })}
       </div>
+
+      {/* Verification Checkbox */}
+      {selectedAIProvider?.provider && (
+        <ProviderVerification
+          type="ai"
+          provider={currentProvider}
+          selectedProvider={selectedAIProvider}
+          isConfigured={!isApiKeyEmpty()}
+          onVerificationChange={handleVerificationChange}
+        />
+      )}
     </div>
   );
 };

--- a/src/pages/dev/components/ai-configs/index.tsx
+++ b/src/pages/dev/components/ai-configs/index.tsx
@@ -1,7 +1,8 @@
 import { Header } from "@/components";
 import { UseSettingsReturn } from "@/types";
 import { Providers } from "./Providers";
-import { CustomProviders } from "./CustomProvider";
+
+export { CustomProviders as AICustomProviders } from "./CustomProvider";
 
 export const AIProviders = (settings: UseSettingsReturn) => {
   return (
@@ -12,8 +13,6 @@ export const AIProviders = (settings: UseSettingsReturn) => {
         isMainTitle
       />
 
-      {/* Custom Provider */}
-      <CustomProviders {...settings} />
       {/* Providers Selection */}
       <Providers {...settings} />
     </div>

--- a/src/pages/dev/components/index.ts
+++ b/src/pages/dev/components/index.ts
@@ -1,3 +1,4 @@
 export * from "./ai-configs";
 export * from "./stt-configs";
 export * from "./MeetwingsApiSetup";
+export * from "./SetupProgressHeader";

--- a/src/pages/dev/components/stt-configs/Providers.tsx
+++ b/src/pages/dev/components/stt-configs/Providers.tsx
@@ -1,8 +1,8 @@
-import { Button, Header, Input, Selection, TextInput, ModelSelector } from "@/components";
-import { UseSettingsReturn } from "@/types";
+import { Button, Header, Input, Selection, TextInput, ModelSelector, ProviderVerification } from "@/components";
+import { UseSettingsReturn, TYPE_PROVIDER } from "@/types";
 import curl2Json, { ResultJSON } from "@bany/curl-to-json";
 import { KeyIcon, TrashIcon, ExternalLink } from "lucide-react";
-import { useEffect, useState } from "react";
+import { useEffect, useState, useCallback } from "react";
 import { getSTTProviderInfo } from "@/config/models.constants";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import { toast } from "sonner";
@@ -26,6 +26,17 @@ export const Providers = ({
 }: UseSettingsReturn) => {
   const [localSelectedProvider, setLocalSelectedProvider] =
     useState<ResultJSON | null>(null);
+  const [, forceUpdate] = useState({});
+
+  // Get the current provider object
+  const currentProvider = allSttProviders?.find(
+    (p: TYPE_PROVIDER) => p?.id === selectedSttProvider?.provider
+  ) as TYPE_PROVIDER | undefined;
+
+  // Force re-render when verification changes to update parent state
+  const handleVerificationChange = useCallback(() => {
+    forceUpdate({});
+  }, []);
 
   useEffect(() => {
     if (selectedSttProvider?.provider) {
@@ -288,6 +299,17 @@ export const Providers = ({
             );
           })}
       </div>
+
+      {/* Verification Checkbox */}
+      {selectedSttProvider?.provider && (
+        <ProviderVerification
+          type="stt"
+          provider={currentProvider}
+          selectedProvider={selectedSttProvider}
+          isConfigured={!isApiKeyEmpty()}
+          onVerificationChange={handleVerificationChange}
+        />
+      )}
     </div>
   );
 };

--- a/src/pages/dev/components/stt-configs/Providers.tsx
+++ b/src/pages/dev/components/stt-configs/Providers.tsx
@@ -5,6 +5,18 @@ import { KeyIcon, TrashIcon, ExternalLink } from "lucide-react";
 import { useEffect, useState } from "react";
 import { getSTTProviderInfo } from "@/config/models.constants";
 import { openUrl } from "@tauri-apps/plugin-opener";
+import { toast } from "sonner";
+
+const handleOpenUrl = async (url: string) => {
+  try {
+    await openUrl(url);
+  } catch (error) {
+    console.error("Failed to open URL:", error);
+    toast.error("Failed to open link", {
+      description: "Please try again or copy the URL manually.",
+    });
+  }
+};
 
 export const Providers = ({
   allSttProviders,
@@ -83,18 +95,19 @@ export const Providers = ({
       {selectedSttProvider?.provider && !allSttProviders?.find(p => p?.id === selectedSttProvider?.provider)?.isCustom && (() => {
         const providerInfo = getSTTProviderInfo(selectedSttProvider.provider);
         if (!providerInfo) return null;
+        const { pricingUrl } = providerInfo;
         return (
           <div className="flex flex-wrap gap-2 py-2">
             <button
-              onClick={() => openUrl(providerInfo.signupUrl)}
+              onClick={() => handleOpenUrl(providerInfo.signupUrl)}
               className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm bg-primary/10 hover:bg-primary/20 text-primary rounded-md transition-colors"
             >
               <ExternalLink className="h-3.5 w-3.5" />
               Get API Key from {providerInfo.name}
             </button>
-            {providerInfo.pricingUrl && (
+            {pricingUrl && (
               <button
-                onClick={() => openUrl(providerInfo.pricingUrl!)}
+                onClick={() => handleOpenUrl(pricingUrl)}
                 className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm bg-secondary hover:bg-secondary/80 text-secondary-foreground rounded-md transition-colors"
               >
                 <ExternalLink className="h-3.5 w-3.5" />

--- a/src/pages/dev/components/stt-configs/Providers.tsx
+++ b/src/pages/dev/components/stt-configs/Providers.tsx
@@ -1,8 +1,10 @@
-import { Button, Header, Input, Selection, TextInput } from "@/components";
+import { Button, Header, Input, Selection, TextInput, ModelSelector } from "@/components";
 import { UseSettingsReturn } from "@/types";
 import curl2Json, { ResultJSON } from "@bany/curl-to-json";
-import { KeyIcon, TrashIcon } from "lucide-react";
+import { KeyIcon, TrashIcon, ExternalLink } from "lucide-react";
 import { useEffect, useState } from "react";
+import { getSTTProviderInfo } from "@/config/models.constants";
+import { openUrl } from "@tauri-apps/plugin-opener";
 
 export const Providers = ({
   allSttProviders,
@@ -76,6 +78,33 @@ export const Providers = ({
           description={`If you want to use different url or method, you can always create a custom provider.`}
         />
       ) : null}
+
+      {/* Provider signup/pricing links */}
+      {selectedSttProvider?.provider && !allSttProviders?.find(p => p?.id === selectedSttProvider?.provider)?.isCustom && (() => {
+        const providerInfo = getSTTProviderInfo(selectedSttProvider.provider);
+        if (!providerInfo) return null;
+        return (
+          <div className="flex flex-wrap gap-2 py-2">
+            <button
+              onClick={() => openUrl(providerInfo.signupUrl)}
+              className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm bg-primary/10 hover:bg-primary/20 text-primary rounded-md transition-colors"
+            >
+              <ExternalLink className="h-3.5 w-3.5" />
+              Get API Key from {providerInfo.name}
+            </button>
+            {providerInfo.pricingUrl && (
+              <button
+                onClick={() => openUrl(providerInfo.pricingUrl!)}
+                className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm bg-secondary hover:bg-secondary/80 text-secondary-foreground rounded-md transition-colors"
+              >
+                <ExternalLink className="h-3.5 w-3.5" />
+                View Pricing
+              </button>
+            )}
+          </div>
+        );
+      })()}
+
       {findKeyAndValue("api_key") ? (
         <div className="space-y-2">
           <Header
@@ -185,6 +214,39 @@ export const Providers = ({
               return selectedSttProvider.variables[variable.key] || "";
             };
 
+            const isModelVariable = variable?.key === "model";
+            const currentProvider = allSttProviders?.find(
+              (p) => p?.id === selectedSttProvider?.provider
+            );
+            const isCustomProvider = currentProvider?.isCustom;
+            const providerDisplayName = isCustomProvider
+              ? "Custom Provider"
+              : currentProvider?.name || selectedSttProvider?.provider;
+
+            // Use ModelSelector for model variable if provider has predefined models
+            if (isModelVariable && !isCustomProvider && selectedSttProvider?.provider) {
+              return (
+                <div key={variable?.key}>
+                  <ModelSelector
+                    providerId={selectedSttProvider.provider}
+                    selectedModel={getVariableValue()}
+                    onModelChange={(model) => {
+                      if (!variable?.key || !selectedSttProvider) return;
+                      onSetSelectedSttProvider({
+                        ...selectedSttProvider,
+                        variables: {
+                          ...selectedSttProvider.variables,
+                          [variable.key]: model,
+                        },
+                      });
+                    }}
+                    type="stt"
+                    providerDisplayName={providerDisplayName}
+                  />
+                </div>
+              );
+            }
+
             return (
               <div className="space-y-1" key={variable?.key}>
                 <Header
@@ -192,22 +254,10 @@ export const Providers = ({
                   description={`add your preferred ${variable?.key?.replace(
                     /_/g,
                     " "
-                  )} for ${
-                    allSttProviders?.find(
-                      (p) => p?.id === selectedSttProvider?.provider
-                    )?.isCustom
-                      ? "Custom Provider"
-                      : selectedSttProvider?.provider
-                  }`}
+                  )} for ${providerDisplayName}`}
                 />
                 <TextInput
-                  placeholder={`Enter ${
-                    allSttProviders?.find(
-                      (p) => p?.id === selectedSttProvider?.provider
-                    )?.isCustom
-                      ? "Custom Provider"
-                      : selectedSttProvider?.provider
-                  } ${variable?.key?.replace(/_/g, " ") || "value"}`}
+                  placeholder={`Enter ${providerDisplayName} ${variable?.key?.replace(/_/g, " ") || "value"}`}
                   value={getVariableValue()}
                   onChange={(value) => {
                     if (!variable?.key || !selectedSttProvider) return;

--- a/src/pages/dev/components/stt-configs/index.tsx
+++ b/src/pages/dev/components/stt-configs/index.tsx
@@ -1,7 +1,8 @@
 import { Header } from "@/components";
 import { UseSettingsReturn } from "@/types";
 import { Providers } from "./Providers";
-import { CustomProviders } from "./CustomProvider";
+
+export { CustomProviders as STTCustomProviders } from "./CustomProvider";
 
 export const STTProviders = (settings: UseSettingsReturn) => {
   return (
@@ -12,8 +13,6 @@ export const STTProviders = (settings: UseSettingsReturn) => {
         isMainTitle
       />
 
-      {/* Custom Provider */}
-      <CustomProviders {...settings} />
       {/* Providers Selection */}
       <Providers {...settings} />
     </div>

--- a/src/pages/dev/index.tsx
+++ b/src/pages/dev/index.tsx
@@ -1,4 +1,4 @@
-import { AIProviders, STTProviders, MeetwingsApiSetup } from "./components";
+import { AIProviders, STTProviders, MeetwingsApiSetup, SetupProgressHeader } from "./components";
 import Contribute from "@/components/Contribute";
 import { useSettings } from "@/hooks";
 import { PageLayout } from "@/layouts";
@@ -7,16 +7,46 @@ const DevSpace = () => {
   const settings = useSettings();
 
   return (
-    <PageLayout title="Dev Space" description="Manage your dev space">
-      <Contribute />
-      {/* Meetwings API Setup */}
-      <MeetwingsApiSetup />
+    <PageLayout
+      title="API Setup"
+      description="Connect your AI and speech services to get started"
+    >
+      {/* Setup Progress */}
+      <SetupProgressHeader />
 
-      {/* AI Provider Selection */}
-      <AIProviders {...settings} />
+      {/* Required Section */}
+      <div className="space-y-6">
+        <div className="flex items-center gap-2 mb-2">
+          <h2 className="text-sm font-semibold text-foreground">Required</h2>
+          <span className="text-xs px-2 py-0.5 rounded-full bg-red-500/10 text-red-600 dark:text-red-400">
+            Must configure
+          </span>
+        </div>
 
-      {/* STT Providers */}
-      <STTProviders {...settings} />
+        {/* AI Provider Selection */}
+        <AIProviders {...settings} />
+
+        {/* STT Providers */}
+        <STTProviders {...settings} />
+      </div>
+
+      {/* Optional Section */}
+      <div className="mt-8 pt-6 border-t border-border">
+        <div className="flex items-center gap-2 mb-4">
+          <h2 className="text-sm font-semibold text-foreground">Optional</h2>
+          <span className="text-xs px-2 py-0.5 rounded-full bg-muted text-muted-foreground">
+            Premium features
+          </span>
+        </div>
+
+        {/* Meetwings API Setup */}
+        <MeetwingsApiSetup />
+      </div>
+
+      {/* Contribute Banner (moved to bottom) */}
+      <div className="mt-8">
+        <Contribute />
+      </div>
     </PageLayout>
   );
 };

--- a/src/pages/dev/index.tsx
+++ b/src/pages/dev/index.tsx
@@ -7,11 +7,12 @@ import {
   STTCustomProviders,
 } from "./components";
 import Contribute from "@/components/Contribute";
-import { useSettings } from "@/hooks";
+import { useSettings, useSetupStatus } from "@/hooks";
 import { PageLayout } from "@/layouts";
 
 const DevSpace = () => {
   const settings = useSettings();
+  const { isComplete } = useSetupStatus();
 
   return (
     <PageLayout
@@ -25,9 +26,11 @@ const DevSpace = () => {
       <div className="space-y-6">
         <div className="flex items-center gap-2 mb-2">
           <h2 className="text-sm font-semibold text-foreground">Required</h2>
-          <span className="text-xs px-2 py-0.5 rounded-full bg-red-500/10 text-red-600 dark:text-red-400">
-            Must configure
-          </span>
+          {!isComplete && (
+            <span className="text-xs px-2 py-0.5 rounded-full bg-red-500/10 text-red-600 dark:text-red-400">
+              Must configure
+            </span>
+          )}
         </div>
 
         {/* AI Provider Selection */}

--- a/src/pages/dev/index.tsx
+++ b/src/pages/dev/index.tsx
@@ -1,4 +1,11 @@
-import { AIProviders, STTProviders, MeetwingsApiSetup, SetupProgressHeader } from "./components";
+import {
+  AIProviders,
+  STTProviders,
+  MeetwingsApiSetup,
+  SetupProgressHeader,
+  AICustomProviders,
+  STTCustomProviders,
+} from "./components";
 import Contribute from "@/components/Contribute";
 import { useSettings } from "@/hooks";
 import { PageLayout } from "@/layouts";
@@ -35,12 +42,20 @@ const DevSpace = () => {
         <div className="flex items-center gap-2 mb-4">
           <h2 className="text-sm font-semibold text-foreground">Optional</h2>
           <span className="text-xs px-2 py-0.5 rounded-full bg-muted text-muted-foreground">
-            Premium features
+            Advanced features
           </span>
         </div>
 
-        {/* Meetwings API Setup */}
-        <MeetwingsApiSetup />
+        <div className="space-y-6">
+          {/* Meetwings API Setup */}
+          <MeetwingsApiSetup />
+
+          {/* Custom AI Providers */}
+          <AICustomProviders {...settings} />
+
+          {/* Custom STT Providers */}
+          <STTCustomProviders {...settings} />
+        </div>
       </div>
 
       {/* Contribute Banner (moved to bottom) */}

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,4 +1,4 @@
-import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
+import { BrowserRouter as Router, Routes, Route, Navigate } from "react-router-dom";
 import {
   Dashboard,
   App,
@@ -37,7 +37,9 @@ export default function AppRoutes() {
           <Route path="/context-memory" element={<ContextMemory />} />
           <Route path="/speakers" element={<Speakers />} />
           <Route path="/language" element={<Language />} />
-          <Route path="/dev-space" element={<DevSpace />} />
+          <Route path="/api-setup" element={<DevSpace />} />
+          {/* Redirect old route for backward compatibility */}
+          <Route path="/dev-space" element={<Navigate to="/api-setup" replace />} />
         </Route>
       </Routes>
     </Router>

--- a/src/tests/api-test.integration.test.ts
+++ b/src/tests/api-test.integration.test.ts
@@ -1,0 +1,633 @@
+/**
+ * Integration Tests for API Test Functions
+ *
+ * Tests the testAIProvider and testSTTProvider functions with actual
+ * provider CURL templates to ensure they correctly parse and handle
+ * different API formats.
+ *
+ * These are unit tests that mock the network layer - they test the
+ * parsing and processing logic without making actual API calls.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { testAIProvider, testSTTProvider, TestResult } from "@/lib/functions/api-test.function";
+import { TYPE_PROVIDER } from "@/types";
+
+// Mock Tauri HTTP plugin
+vi.mock("@tauri-apps/plugin-http", () => ({
+  fetch: vi.fn(),
+}));
+
+// Mock the global fetch
+const mockFetch = vi.fn();
+global.fetch = mockFetch;
+
+// Import the mocked Tauri fetch
+import { fetch as tauriFetch } from "@tauri-apps/plugin-http";
+const mockTauriFetch = vi.mocked(tauriFetch);
+
+// Helper to create mock response
+function createMockResponse(options: {
+  status: number;
+  ok?: boolean;
+  json?: unknown;
+  text?: string;
+}): Response {
+  return {
+    status: options.status,
+    ok: options.ok ?? (options.status >= 200 && options.status < 300),
+    json: async () => options.json,
+    text: async () => options.text || "",
+    statusText: options.text || `HTTP ${options.status}`,
+  } as Response;
+}
+
+describe("testAIProvider", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  describe("OpenAI provider format", () => {
+    const openaiProvider: TYPE_PROVIDER = {
+      id: "openai",
+      name: "OpenAI",
+      curl: `curl https://api.openai.com/v1/chat/completions \\
+        -H "Content-Type: application/json" \\
+        -H "Authorization: Bearer {{API_KEY}}" \\
+        -d '{
+          "model": "{{MODEL}}",
+          "messages": [{"role": "system", "content": "{{SYSTEM_PROMPT}}"}, {"role": "user", "content": "{{TEXT}}"}]
+        }'`,
+      responseContentPath: "choices[0].message.content",
+      isStreaming: true,
+    };
+
+    const selectedProvider = {
+      provider: "openai",
+      variables: {
+        api_key: "sk-test-key-12345",
+        model: "gpt-4o",
+      },
+    };
+
+    it("should return success when API responds with valid content", async () => {
+      mockFetch.mockResolvedValueOnce(
+        createMockResponse({
+          status: 200,
+          json: {
+            choices: [{ message: { content: "OK" } }],
+          },
+        })
+      );
+
+      const result = await testAIProvider(openaiProvider, selectedProvider);
+
+      expect(result.success).toBe(true);
+      expect(result.message).toBe("Connection verified");
+    });
+
+    it("should return auth error for 401 status", async () => {
+      mockFetch.mockResolvedValueOnce(
+        createMockResponse({
+          status: 401,
+          ok: false,
+          text: "Unauthorized",
+        })
+      );
+
+      const result = await testAIProvider(openaiProvider, selectedProvider);
+
+      expect(result.success).toBe(false);
+      expect(result.message).toBe("Authentication failed: Invalid API key");
+    });
+
+    it("should return success for 429 rate limit (key is valid)", async () => {
+      mockFetch.mockResolvedValueOnce(
+        createMockResponse({
+          status: 429,
+          ok: false,
+          text: "Rate limited",
+        })
+      );
+
+      const result = await testAIProvider(openaiProvider, selectedProvider);
+
+      expect(result.success).toBe(true);
+      expect(result.message).toBe("Authentication verified (rate limited)");
+    });
+
+    it("should fail when no API key provided", async () => {
+      const result = await testAIProvider(openaiProvider, {
+        provider: "openai",
+        variables: { model: "gpt-4o" },
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.message).toBe("Configuration error: API key not provided");
+    });
+  });
+
+  describe("Claude provider format", () => {
+    const claudeProvider: TYPE_PROVIDER = {
+      id: "claude",
+      name: "Claude",
+      curl: `curl https://api.anthropic.com/v1/messages \\
+        -H "x-api-key: {{API_KEY}}" \\
+        -H "anthropic-version: 2023-06-01" \\
+        -H "content-type: application/json" \\
+        -d '{
+          "model": "{{MODEL}}",
+          "system": "{{SYSTEM_PROMPT}}",
+          "messages": [{"role": "user", "content": "{{TEXT}}"}],
+          "max_tokens": 1024
+        }'`,
+      responseContentPath: "content[0].text",
+      isStreaming: true,
+    };
+
+    const selectedProvider = {
+      provider: "claude",
+      variables: {
+        api_key: "sk-ant-test-key",
+        model: "claude-3-5-sonnet-20241022",
+      },
+    };
+
+    it("should parse Claude response format correctly", async () => {
+      mockFetch.mockResolvedValueOnce(
+        createMockResponse({
+          status: 200,
+          json: {
+            content: [{ text: "OK" }],
+          },
+        })
+      );
+
+      const result = await testAIProvider(claudeProvider, selectedProvider);
+
+      expect(result.success).toBe(true);
+    });
+
+    it("should handle 403 forbidden as auth error", async () => {
+      mockFetch.mockResolvedValueOnce(
+        createMockResponse({
+          status: 403,
+          ok: false,
+          text: "Forbidden",
+        })
+      );
+
+      const result = await testAIProvider(claudeProvider, selectedProvider);
+
+      expect(result.success).toBe(false);
+      expect(result.message).toBe("Authentication failed: Invalid API key");
+    });
+  });
+
+  describe("Gemini provider format", () => {
+    const geminiProvider: TYPE_PROVIDER = {
+      id: "gemini",
+      name: "Gemini",
+      curl: `curl "https://generativelanguage.googleapis.com/v1beta/openai/chat/completions" \\
+        -H "Authorization: Bearer {{API_KEY}}" \\
+        -H "Content-Type: application/json" \\
+        -d '{
+          "model": "{{MODEL}}",
+          "messages": [{"role": "user", "content": "{{TEXT}}"}]
+        }'`,
+      responseContentPath: "choices[0].message.content",
+      isStreaming: true,
+    };
+
+    const selectedProvider = {
+      provider: "gemini",
+      variables: {
+        api_key: "AIza-test-key",
+        model: "gemini-2.0-flash",
+      },
+    };
+
+    it("should handle Gemini API format", async () => {
+      mockFetch.mockResolvedValueOnce(
+        createMockResponse({
+          status: 200,
+          json: {
+            choices: [{ message: { content: "OK" } }],
+          },
+        })
+      );
+
+      const result = await testAIProvider(geminiProvider, selectedProvider);
+
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe("Error handling", () => {
+    const provider: TYPE_PROVIDER = {
+      id: "test",
+      name: "Test",
+      curl: `curl https://api.test.com/v1/test \\
+        -H "Authorization: Bearer {{API_KEY}}" \\
+        -d '{"model": "{{MODEL}}"}'`,
+      responseContentPath: "content",
+      isStreaming: false,
+    };
+
+    const selectedProvider = {
+      provider: "test",
+      variables: {
+        api_key: "test-key",
+        model: "test-model",
+      },
+    };
+
+    it("should return error when no provider configured", async () => {
+      const result = await testAIProvider(undefined, selectedProvider);
+
+      expect(result.success).toBe(false);
+      expect(result.message).toBe("Configuration error: No provider configured");
+    });
+
+    it("should handle invalid JSON response", async () => {
+      mockFetch.mockResolvedValueOnce({
+        status: 200,
+        ok: true,
+        json: async () => {
+          throw new Error("Invalid JSON");
+        },
+        text: async () => "Not JSON",
+      } as Response);
+
+      const result = await testAIProvider(provider, selectedProvider);
+
+      expect(result.success).toBe(false);
+      expect(result.message).toBe("Response error: Invalid response format");
+    });
+
+    it("should handle network errors", async () => {
+      mockFetch.mockRejectedValueOnce(new Error("Network error: fetch failed"));
+
+      const result = await testAIProvider(provider, selectedProvider);
+
+      expect(result.success).toBe(false);
+      expect(result.message).toBe("Network error: Connection failed");
+    });
+
+    it("should handle timeout errors", async () => {
+      const abortError = new Error("Request timed out after 10 seconds");
+      abortError.name = "AbortError";
+      mockFetch.mockRejectedValueOnce(abortError);
+
+      const result = await testAIProvider(provider, selectedProvider);
+
+      expect(result.success).toBe(false);
+      expect(result.message).toBe("Network error: Connection timed out");
+    });
+
+    it("should handle 500 server errors", async () => {
+      mockFetch.mockResolvedValueOnce(
+        createMockResponse({
+          status: 500,
+          ok: false,
+          text: "Internal Server Error",
+        })
+      );
+
+      const result = await testAIProvider(provider, selectedProvider);
+
+      expect(result.success).toBe(false);
+      expect(result.message).toBe("Response error: API returned 500");
+    });
+  });
+});
+
+describe("testSTTProvider", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  describe("OpenAI Whisper format (form data)", () => {
+    const whisperProvider: TYPE_PROVIDER = {
+      id: "openai-whisper",
+      name: "OpenAI Whisper",
+      curl: `curl -X POST "https://api.openai.com/v1/audio/transcriptions" \\
+        -H "Authorization: Bearer {{API_KEY}}" \\
+        -F "file={{AUDIO}}" \\
+        -F "model={{MODEL}}" \\
+        -F "language={{LANGUAGE}}"`,
+      responseContentPath: "text",
+      isStreaming: false,
+    };
+
+    const selectedProvider = {
+      provider: "openai-whisper",
+      variables: {
+        api_key: "sk-test-key",
+        model: "whisper-1",
+      },
+    };
+
+    it("should verify API key with minimal WAV file", async () => {
+      mockTauriFetch.mockResolvedValueOnce(
+        createMockResponse({
+          status: 400,
+          ok: false,
+          text: "Audio too short",
+        })
+      );
+
+      const result = await testSTTProvider(whisperProvider, selectedProvider);
+
+      // 400 with non-auth error means key is valid
+      expect(result.success).toBe(true);
+      expect(result.message).toBe("API key verified");
+    });
+
+    it("should detect invalid API key from 401", async () => {
+      mockTauriFetch.mockResolvedValueOnce(
+        createMockResponse({
+          status: 401,
+          ok: false,
+          text: "Unauthorized",
+        })
+      );
+
+      const result = await testSTTProvider(whisperProvider, selectedProvider);
+
+      expect(result.success).toBe(false);
+      expect(result.message).toBe("Authentication failed: Invalid API key");
+    });
+
+    it("should detect auth error disguised as 400", async () => {
+      mockTauriFetch.mockResolvedValueOnce(
+        createMockResponse({
+          status: 400,
+          ok: false,
+          text: "Invalid API key provided",
+        })
+      );
+
+      const result = await testSTTProvider(whisperProvider, selectedProvider);
+
+      expect(result.success).toBe(false);
+      expect(result.message).toBe("Authentication failed: Invalid API key");
+    });
+  });
+
+  describe("Groq Whisper format", () => {
+    const groqProvider: TYPE_PROVIDER = {
+      id: "groq",
+      name: "Groq Whisper",
+      curl: `curl -X POST https://api.groq.com/openai/v1/audio/transcriptions \\
+        -H "Authorization: bearer {{API_KEY}}" \\
+        -F "file={{AUDIO}}" \\
+        -F model={{MODEL}}`,
+      responseContentPath: "text",
+      isStreaming: false,
+    };
+
+    const selectedProvider = {
+      provider: "groq",
+      variables: {
+        api_key: "gsk_test_key",
+        model: "whisper-large-v3",
+      },
+    };
+
+    it("should handle Groq API format", async () => {
+      mockTauriFetch.mockResolvedValueOnce(
+        createMockResponse({
+          status: 200,
+          json: { text: "Test transcription" },
+        })
+      );
+
+      const result = await testSTTProvider(groqProvider, selectedProvider);
+
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe("Deepgram format (binary upload)", () => {
+    const deepgramProvider: TYPE_PROVIDER = {
+      id: "deepgram-stt",
+      name: "Deepgram Speech-to-Text",
+      curl: `curl -X POST "https://api.deepgram.com/v1/listen?model={{MODEL}}&language={{LANGUAGE}}" \\
+        -H "Authorization: TOKEN {{API_KEY}}" \\
+        -H "Content-Type: audio/wav" \\
+        --data-binary {{AUDIO}}`,
+      responseContentPath: "results.channels[0].alternatives[0].transcript",
+      isStreaming: false,
+    };
+
+    const selectedProvider = {
+      provider: "deepgram-stt",
+      variables: {
+        api_key: "dg_test_key",
+        model: "nova-2",
+      },
+    };
+
+    it("should handle binary upload format", async () => {
+      mockTauriFetch.mockResolvedValueOnce(
+        createMockResponse({
+          status: 200,
+          json: {
+            results: {
+              channels: [{ alternatives: [{ transcript: "Test" }] }],
+            },
+          },
+        })
+      );
+
+      const result = await testSTTProvider(deepgramProvider, selectedProvider);
+
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe("AssemblyAI special handler", () => {
+    const assemblyaiProvider: TYPE_PROVIDER = {
+      id: "assemblyai-diarization",
+      name: "AssemblyAI (with Speaker Diarization)",
+      curl: `curl -X POST "https://api.assemblyai.com/v2/upload" \\
+        -H "Authorization: {{API_KEY}}" \\
+        --data-binary {{AUDIO}}`,
+      responseContentPath: "upload_url",
+      isStreaming: false,
+      requiresSpecialHandler: true,
+      specialHandler: "assemblyai-diarization",
+    };
+
+    const selectedProvider = {
+      provider: "assemblyai-diarization",
+      variables: {
+        api_key: "assembly_test_key",
+      },
+    };
+
+    it("should use special handler for AssemblyAI", async () => {
+      mockTauriFetch.mockResolvedValueOnce(
+        createMockResponse({
+          status: 200,
+          json: { id: "transcript-id" },
+        })
+      );
+
+      const result = await testSTTProvider(assemblyaiProvider, selectedProvider);
+
+      expect(result.success).toBe(true);
+      // Verify it used the special /v2/transcript endpoint
+      expect(mockTauriFetch).toHaveBeenCalledWith(
+        "https://api.assemblyai.com/v2/transcript",
+        expect.objectContaining({
+          method: "GET",
+          headers: { Authorization: "assembly_test_key" },
+        })
+      );
+    });
+
+    it("should detect invalid AssemblyAI key", async () => {
+      mockTauriFetch.mockResolvedValueOnce(
+        createMockResponse({
+          status: 401,
+          ok: false,
+          text: "Unauthorized",
+        })
+      );
+
+      const result = await testSTTProvider(assemblyaiProvider, selectedProvider);
+
+      expect(result.success).toBe(false);
+      expect(result.message).toBe("Authentication failed: Invalid API key");
+    });
+  });
+
+  describe("JSON body format (unsupported)", () => {
+    const googleProvider: TYPE_PROVIDER = {
+      id: "google-stt",
+      name: "Google Speech-to-Text",
+      curl: `curl -X POST "https://speech.googleapis.com/v1/speech:recognize" \\
+        -H "Authorization: Bearer {{API_KEY}}" \\
+        -H "Content-Type: application/json" \\
+        -d '{
+          "config": { "encoding": "LINEAR16", "sampleRateHertz": 16000 },
+          "audio": { "content": "{{AUDIO}}" }
+        }'`,
+      responseContentPath: "results[0].alternatives[0].transcript",
+      isStreaming: false,
+    };
+
+    const selectedProvider = {
+      provider: "google-stt",
+      variables: {
+        api_key: "google_test_key",
+      },
+    };
+
+    it("should return unsupported for JSON body APIs", async () => {
+      const result = await testSTTProvider(googleProvider, selectedProvider);
+
+      expect(result.success).toBe(false);
+      expect(result.message).toBe("Configuration error: API format not supported for verification");
+      expect(result.error).toContain("Automatic verification is not supported");
+    });
+  });
+
+  describe("Error handling", () => {
+    const provider: TYPE_PROVIDER = {
+      id: "test-stt",
+      name: "Test STT",
+      curl: `curl -X POST "https://api.test.com/stt" \\
+        -H "Authorization: Bearer {{API_KEY}}" \\
+        -F "file={{AUDIO}}"`,
+      responseContentPath: "text",
+      isStreaming: false,
+    };
+
+    const selectedProvider = {
+      provider: "test-stt",
+      variables: {
+        api_key: "test-key",
+      },
+    };
+
+    it("should fail when no provider configured", async () => {
+      const result = await testSTTProvider(undefined, selectedProvider);
+
+      expect(result.success).toBe(false);
+      expect(result.message).toBe("Configuration error: No provider configured");
+    });
+
+    it("should fail when no API key provided", async () => {
+      const result = await testSTTProvider(provider, {
+        provider: "test-stt",
+        variables: {},
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.message).toBe("Configuration error: API key not provided");
+    });
+  });
+});
+
+describe("Variable replacement", () => {
+  const provider: TYPE_PROVIDER = {
+    id: "test",
+    name: "Test",
+    curl: `curl "https://api.test.com/{{REGION}}/v1" \\
+      -H "Authorization: Bearer {{API_KEY}}" \\
+      -H "X-Custom: {{CUSTOM_HEADER}}" \\
+      -d '{"model": "{{MODEL}}"}'`,
+    responseContentPath: "content",
+    isStreaming: false,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should fail when required variables are missing", async () => {
+    const result = await testAIProvider(provider, {
+      provider: "test",
+      variables: {
+        api_key: "test-key",
+        model: "test-model",
+        // Missing REGION and CUSTOM_HEADER
+      },
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.message).toContain("Configuration error: Missing");
+  });
+
+  it("should succeed when all variables are provided", async () => {
+    mockFetch.mockResolvedValueOnce(
+      createMockResponse({
+        status: 200,
+        json: { content: "OK" },
+      })
+    );
+
+    const result = await testAIProvider(provider, {
+      provider: "test",
+      variables: {
+        api_key: "test-key",
+        model: "test-model",
+        region: "us-east-1",
+        custom_header: "custom-value",
+      },
+    });
+
+    expect(result.success).toBe(true);
+  });
+});

--- a/src/tests/secure-provider-configs.test.ts
+++ b/src/tests/secure-provider-configs.test.ts
@@ -1,0 +1,437 @@
+/**
+ * Tests for secure-provider-configs.ts
+ *
+ * Critical test cases:
+ * - Secure storage migration from localStorage
+ * - Cache consistency with persistent storage
+ * - Race conditions on concurrent saves
+ * - Loading and saving provider configurations
+ */
+
+import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
+
+// Mock the secure-storage module before importing the module under test
+vi.mock("@/lib/secure-storage", () => ({
+  secureSet: vi.fn(),
+  secureGet: vi.fn(),
+  secureDelete: vi.fn(),
+}));
+
+import {
+  loadSecureAIConfigs,
+  loadSecureSTTConfigs,
+  saveSecureAIConfig,
+  saveSecureSTTConfig,
+  getCachedAIConfig,
+  getCachedSTTConfig,
+  updateAIConfigCache,
+  updateSTTConfigCache,
+  clearSecureProviderConfigs,
+  migrateProviderConfigsToSecureStorage,
+} from "@/lib/storage/secure-provider-configs";
+import { secureSet, secureGet, secureDelete } from "@/lib/secure-storage";
+
+describe("secure-provider-configs", () => {
+  let localStorageData: Record<string, string>;
+  let secureStorageData: Record<string, string>;
+
+  beforeEach(async () => {
+    // Reset localStorage mock
+    localStorageData = {};
+    vi.mocked(localStorage.getItem).mockImplementation((key: string) => {
+      return localStorageData[key] || null;
+    });
+    vi.mocked(localStorage.setItem).mockImplementation((key: string, value: string) => {
+      localStorageData[key] = value;
+    });
+    vi.mocked(localStorage.removeItem).mockImplementation((key: string) => {
+      delete localStorageData[key];
+    });
+
+    // Reset secure storage mock
+    secureStorageData = {};
+    vi.mocked(secureSet).mockImplementation(async (key: string, value: string) => {
+      secureStorageData[key] = value;
+    });
+    vi.mocked(secureGet).mockImplementation(async (key: string) => {
+      return secureStorageData[key] || null;
+    });
+    vi.mocked(secureDelete).mockImplementation(async (key: string) => {
+      delete secureStorageData[key];
+    });
+
+    // Reset caches by clearing (after mocks are set up)
+    await clearSecureProviderConfigs();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("loadSecureAIConfigs / loadSecureSTTConfigs", () => {
+    it("returns empty object when no configs exist", async () => {
+      const configs = await loadSecureAIConfigs();
+      expect(configs).toEqual({});
+    });
+
+    it("loads configs from secure storage", async () => {
+      // Set data in mock secure storage (after beforeEach clears cache)
+      secureStorageData["secure_ai_provider_configs"] = JSON.stringify({
+        openai: { api_key: "sk-test", model: "gpt-4" },
+      });
+
+      const configs = await loadSecureAIConfigs();
+      expect(configs.openai).toEqual({ api_key: "sk-test", model: "gpt-4" });
+    });
+
+    it("caches loaded configs", async () => {
+      secureStorageData["secure_ai_provider_configs"] = JSON.stringify({
+        openai: { api_key: "sk-test" },
+      });
+
+      // Clear call count after beforeEach
+      vi.mocked(secureGet).mockClear();
+
+      // First load
+      await loadSecureAIConfigs();
+      expect(secureGet).toHaveBeenCalledTimes(1);
+
+      // Second load should use cache
+      await loadSecureAIConfigs();
+      expect(secureGet).toHaveBeenCalledTimes(1); // Still 1, used cache
+    });
+
+    it("handles JSON parse errors gracefully", async () => {
+      // Set invalid JSON data (after beforeEach clears cache)
+      secureStorageData["secure_ai_provider_configs"] = "invalid json";
+
+      const configs = await loadSecureAIConfigs();
+      expect(configs).toEqual({});
+    });
+  });
+
+  describe("saveSecureAIConfig / saveSecureSTTConfig", () => {
+    it("saves config to secure storage", async () => {
+      await saveSecureAIConfig("openai", { api_key: "sk-new", model: "gpt-4" });
+
+      expect(secureSet).toHaveBeenCalledWith(
+        "secure_ai_provider_configs",
+        expect.stringContaining("openai")
+      );
+
+      const stored = JSON.parse(secureStorageData["secure_ai_provider_configs"]);
+      expect(stored.openai).toEqual({ api_key: "sk-new", model: "gpt-4" });
+    });
+
+    it("preserves existing configs when saving new one", async () => {
+      // First save
+      await saveSecureAIConfig("openai", { api_key: "sk-openai" });
+
+      // Second save different provider
+      await saveSecureAIConfig("anthropic", { api_key: "sk-anthropic" });
+
+      const stored = JSON.parse(secureStorageData["secure_ai_provider_configs"]);
+      expect(stored.openai).toEqual({ api_key: "sk-openai" });
+      expect(stored.anthropic).toEqual({ api_key: "sk-anthropic" });
+    });
+
+    it("updates cache immediately", async () => {
+      await saveSecureAIConfig("openai", { api_key: "sk-test" });
+
+      const cached = getCachedAIConfig("openai");
+      expect(cached).toEqual({ api_key: "sk-test" });
+    });
+
+    it("overwrites existing config for same provider", async () => {
+      await saveSecureAIConfig("openai", { api_key: "old-key" });
+      await saveSecureAIConfig("openai", { api_key: "new-key" });
+
+      const stored = JSON.parse(secureStorageData["secure_ai_provider_configs"]);
+      expect(stored.openai).toEqual({ api_key: "new-key" });
+    });
+  });
+
+  describe("getCachedAIConfig / getCachedSTTConfig", () => {
+    it("returns undefined when cache is empty", async () => {
+      await clearSecureProviderConfigs();
+      // Force empty cache
+      const cached = getCachedAIConfig("openai");
+      expect(cached).toBeUndefined();
+    });
+
+    it("returns cached config after load", async () => {
+      // Set data in mock secure storage (after beforeEach clears cache)
+      secureStorageData["secure_ai_provider_configs"] = JSON.stringify({
+        openai: { api_key: "cached-key" },
+      });
+
+      await loadSecureAIConfigs();
+
+      const cached = getCachedAIConfig("openai");
+      expect(cached).toEqual({ api_key: "cached-key" });
+    });
+
+    it("returns cached config after save", async () => {
+      await saveSecureAIConfig("groq", { api_key: "groq-key" });
+
+      const cached = getCachedAIConfig("groq");
+      expect(cached).toEqual({ api_key: "groq-key" });
+    });
+  });
+
+  describe("updateAIConfigCache / updateSTTConfigCache - Async Saves", () => {
+    it("updates cache and persists to secure storage", async () => {
+      await updateAIConfigCache("openai", { api_key: "test-key" });
+
+      const cached = getCachedAIConfig("openai");
+      expect(cached).toEqual({ api_key: "test-key" });
+      expect(secureSet).toHaveBeenCalled();
+    });
+
+    it("awaits the save to secure storage", async () => {
+      await updateAIConfigCache("openai", { api_key: "async-save" });
+
+      // secureSet should have been awaited
+      expect(secureSet).toHaveBeenCalledWith(
+        "secure_ai_provider_configs",
+        expect.stringContaining("openai")
+      );
+    });
+
+    it("throws on save errors", async () => {
+      vi.mocked(secureSet).mockRejectedValueOnce(new Error("Save failed"));
+
+      // Should throw the error
+      await expect(
+        updateAIConfigCache("openai", { api_key: "error-key" })
+      ).rejects.toThrow("Save failed");
+
+      // Cache should still be updated even if save fails
+      expect(getCachedAIConfig("openai")).toEqual({ api_key: "error-key" });
+    });
+  });
+
+  describe("clearSecureProviderConfigs", () => {
+    it("clears both AI and STT configs", async () => {
+      await saveSecureAIConfig("openai", { api_key: "ai-key" });
+      await saveSecureSTTConfig("whisper", { api_key: "stt-key" });
+
+      await clearSecureProviderConfigs();
+
+      expect(secureDelete).toHaveBeenCalledWith("secure_ai_provider_configs");
+      expect(secureDelete).toHaveBeenCalledWith("secure_stt_provider_configs");
+    });
+
+    it("clears caches", async () => {
+      await saveSecureAIConfig("openai", { api_key: "cached" });
+      await clearSecureProviderConfigs();
+
+      // Cache should be null, getCachedAIConfig returns undefined for null cache
+      expect(getCachedAIConfig("openai")).toBeUndefined();
+    });
+  });
+
+  describe("migrateProviderConfigsToSecureStorage", () => {
+    it("migrates AI configs from localStorage to secure storage", async () => {
+      localStorageData["ai_provider_configs"] = JSON.stringify({
+        openai: { api_key: "local-ai-key" },
+      });
+
+      await migrateProviderConfigsToSecureStorage();
+
+      // Should have been migrated to secure storage
+      expect(secureSet).toHaveBeenCalledWith(
+        "secure_ai_provider_configs",
+        JSON.stringify({ openai: { api_key: "local-ai-key" } })
+      );
+
+      // Should be removed from localStorage
+      expect(localStorageData["ai_provider_configs"]).toBeUndefined();
+    });
+
+    it("migrates STT configs from localStorage to secure storage", async () => {
+      localStorageData["stt_provider_configs"] = JSON.stringify({
+        whisper: { api_key: "local-stt-key" },
+      });
+
+      await migrateProviderConfigsToSecureStorage();
+
+      expect(secureSet).toHaveBeenCalledWith(
+        "secure_stt_provider_configs",
+        JSON.stringify({ whisper: { api_key: "local-stt-key" } })
+      );
+
+      expect(localStorageData["stt_provider_configs"]).toBeUndefined();
+    });
+
+    it("does not overwrite existing secure storage data", async () => {
+      // Existing secure data
+      secureStorageData["secure_ai_provider_configs"] = JSON.stringify({
+        existing: { api_key: "secure-key" },
+      });
+
+      // Old localStorage data
+      localStorageData["ai_provider_configs"] = JSON.stringify({
+        openai: { api_key: "local-key" },
+      });
+
+      await migrateProviderConfigsToSecureStorage();
+
+      // Should NOT have called secureSet (existing data protected)
+      expect(secureSet).not.toHaveBeenCalledWith(
+        "secure_ai_provider_configs",
+        expect.any(String)
+      );
+
+      // But should still remove from localStorage
+      expect(localStorageData["ai_provider_configs"]).toBeUndefined();
+    });
+
+    it("handles missing localStorage data gracefully", async () => {
+      // No localStorage data
+
+      await migrateProviderConfigsToSecureStorage();
+
+      // Should not throw, should not call secureSet
+      expect(secureSet).not.toHaveBeenCalled();
+    });
+
+    it("handles migration errors gracefully", async () => {
+      localStorageData["ai_provider_configs"] = JSON.stringify({
+        openai: { api_key: "test" },
+      });
+
+      vi.mocked(secureSet).mockRejectedValueOnce(new Error("Secure storage error"));
+
+      // Should not throw
+      await migrateProviderConfigsToSecureStorage();
+    });
+  });
+
+  describe("Cache Consistency", () => {
+    it("cache matches persistent storage after save", async () => {
+      const config = { api_key: "consistency-test", model: "gpt-4" };
+      await saveSecureAIConfig("openai", config);
+
+      const cached = getCachedAIConfig("openai");
+      const persisted = JSON.parse(secureStorageData["secure_ai_provider_configs"]).openai;
+
+      expect(cached).toEqual(persisted);
+    });
+
+    it("cache matches persistent storage after load", async () => {
+      // Set data in mock secure storage (after beforeEach clears cache)
+      secureStorageData["secure_stt_provider_configs"] = JSON.stringify({
+        groq: { api_key: "persisted-key" },
+      });
+
+      await loadSecureSTTConfigs();
+
+      const cached = getCachedSTTConfig("groq");
+      const persisted = JSON.parse(secureStorageData["secure_stt_provider_configs"]).groq;
+
+      expect(cached).toEqual(persisted);
+    });
+  });
+
+  describe("Race Conditions - Concurrent Saves", () => {
+    it("handles concurrent saves without data loss", async () => {
+      // Simulate concurrent saves
+      const saves = [
+        saveSecureAIConfig("provider1", { api_key: "key1" }),
+        saveSecureAIConfig("provider2", { api_key: "key2" }),
+        saveSecureAIConfig("provider3", { api_key: "key3" }),
+      ];
+
+      await Promise.all(saves);
+
+      const stored = JSON.parse(secureStorageData["secure_ai_provider_configs"]);
+      expect(stored.provider1).toEqual({ api_key: "key1" });
+      expect(stored.provider2).toEqual({ api_key: "key2" });
+      expect(stored.provider3).toEqual({ api_key: "key3" });
+    });
+
+    it("handles concurrent loads with single storage read", async () => {
+      // Set data in mock secure storage (after beforeEach clears cache)
+      secureStorageData["secure_ai_provider_configs"] = JSON.stringify({
+        openai: { api_key: "test" },
+      });
+
+      // Clear call count after beforeEach
+      vi.mocked(secureGet).mockClear();
+
+      // Concurrent loads
+      const loads = [
+        loadSecureAIConfigs(),
+        loadSecureAIConfigs(),
+        loadSecureAIConfigs(),
+      ];
+
+      const results = await Promise.all(loads);
+
+      // All should return same data
+      expect(results[0]).toEqual(results[1]);
+      expect(results[1]).toEqual(results[2]);
+
+      // Should only read from storage once (due to loading promise)
+      expect(secureGet).toHaveBeenCalledTimes(1);
+    });
+
+    it("handles interleaved save and load operations", async () => {
+      // Interleaved save operations
+      const ops = [
+        saveSecureAIConfig("provider1", { api_key: "key1" }),
+        saveSecureAIConfig("provider2", { api_key: "key2" }),
+        loadSecureAIConfigs(),
+        saveSecureAIConfig("provider3", { api_key: "key3" }),
+      ];
+
+      await Promise.all(ops);
+
+      // Final state should have all providers
+      const cached = await loadSecureAIConfigs();
+      expect(cached.provider1).toEqual({ api_key: "key1" });
+      expect(cached.provider2).toEqual({ api_key: "key2" });
+      expect(cached.provider3).toEqual({ api_key: "key3" });
+    });
+  });
+
+  describe("Edge Cases", () => {
+    it("handles empty provider ID", async () => {
+      await saveSecureAIConfig("", { api_key: "empty-id" });
+
+      const cached = getCachedAIConfig("");
+      expect(cached).toEqual({ api_key: "empty-id" });
+    });
+
+    it("handles empty config object", async () => {
+      await saveSecureAIConfig("openai", {});
+
+      const cached = getCachedAIConfig("openai");
+      expect(cached).toEqual({});
+    });
+
+    it("handles special characters in config values", async () => {
+      const config = {
+        api_key: "sk-!@#$%^&*()_+-={}[]|:;'<>?,./",
+        model: "test-模型",
+      };
+      await saveSecureAIConfig("openai", config);
+
+      const cached = getCachedAIConfig("openai");
+      expect(cached).toEqual(config);
+    });
+
+    it("handles very large configs", async () => {
+      const largeConfig: Record<string, string> = {};
+      for (let i = 0; i < 100; i++) {
+        largeConfig[`key_${i}`] = "a".repeat(100);
+      }
+
+      await saveSecureAIConfig("openai", largeConfig);
+
+      const cached = getCachedAIConfig("openai");
+      expect(Object.keys(cached!).length).toBe(100);
+    });
+  });
+});

--- a/src/tests/verification.storage.test.ts
+++ b/src/tests/verification.storage.test.ts
@@ -370,11 +370,10 @@ describe("verification.storage", () => {
       expect(mockDigest).toHaveBeenCalledWith("SHA-256", expect.any(Uint8Array));
     });
 
-    it("produces empty hash for empty API key", async () => {
-      await setAIVerificationStatus("openai", "gpt-4", "", true);
-
-      const cached = getAIVerificationStatus();
-      expect(cached?.apiKeyHash).toBe("");
+    it("throws error for empty API key", async () => {
+      await expect(
+        setAIVerificationStatus("openai", "gpt-4", "", true)
+      ).rejects.toThrow("API key cannot be empty");
     });
 
     it("produces consistent hashes for same input", async () => {

--- a/src/tests/verification.storage.test.ts
+++ b/src/tests/verification.storage.test.ts
@@ -1,0 +1,430 @@
+/**
+ * Tests for verification.storage.ts
+ *
+ * Critical test cases:
+ * - Verification hash invalidation when API key/model/provider changes
+ * - SHA-256 hashing consistency
+ * - Storage and retrieval correctness
+ * - Secure storage integration
+ * - Migration from localStorage
+ */
+
+import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
+
+// Mock the secure-storage module before importing the module under test
+vi.mock("@/lib/secure-storage", () => ({
+  secureSet: vi.fn(),
+  secureGet: vi.fn(),
+  secureDelete: vi.fn(),
+}));
+
+import {
+  getAIVerificationStatus,
+  getSTTVerificationStatus,
+  setAIVerificationStatus,
+  setSTTVerificationStatus,
+  clearAIVerificationStatus,
+  clearSTTVerificationStatus,
+  isAIVerificationValid,
+  isSTTVerificationValid,
+  getAIVerificationError,
+  getSTTVerificationError,
+  loadVerificationCache,
+  migrateVerificationToSecureStorage,
+  resetVerificationCache,
+} from "@/lib/storage/verification.storage";
+import { secureSet, secureGet, secureDelete } from "@/lib/secure-storage";
+import { STORAGE_KEYS } from "@/config/constants";
+
+// Mock crypto.subtle for SHA-256 hashing
+const mockDigest = vi.fn();
+vi.stubGlobal("crypto", {
+  subtle: {
+    digest: mockDigest,
+  },
+});
+
+// Helper to create mock hash buffer
+function createMockHashBuffer(seed: string): ArrayBuffer {
+  const encoder = new TextEncoder();
+  const data = encoder.encode(seed);
+  // Create a deterministic "hash" based on input
+  const hash = new Uint8Array(32);
+  for (let i = 0; i < 32; i++) {
+    hash[i] = data[i % data.length] ^ (i * 7);
+  }
+  return hash.buffer;
+}
+
+describe("verification.storage", () => {
+  let localStorageData: Record<string, string>;
+  let secureStorageData: Record<string, string>;
+
+  beforeEach(async () => {
+    // Reset localStorage mock
+    localStorageData = {};
+    vi.mocked(localStorage.getItem).mockImplementation((key: string) => {
+      return localStorageData[key] || null;
+    });
+    vi.mocked(localStorage.setItem).mockImplementation((key: string, value: string) => {
+      localStorageData[key] = value;
+    });
+    vi.mocked(localStorage.removeItem).mockImplementation((key: string) => {
+      delete localStorageData[key];
+    });
+
+    // Reset secure storage mock
+    secureStorageData = {};
+    vi.mocked(secureSet).mockImplementation(async (key: string, value: string) => {
+      secureStorageData[key] = value;
+    });
+    vi.mocked(secureGet).mockImplementation(async (key: string) => {
+      return secureStorageData[key] || null;
+    });
+    vi.mocked(secureDelete).mockImplementation(async (key: string) => {
+      delete secureStorageData[key];
+    });
+
+    // Reset crypto mock - return deterministic hash based on input
+    mockDigest.mockImplementation((_algorithm: string, data: ArrayBuffer) => {
+      const decoder = new TextDecoder();
+      const input = decoder.decode(data);
+      return Promise.resolve(createMockHashBuffer(input));
+    });
+
+    // Reset cache for each test
+    resetVerificationCache();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("loadVerificationCache", () => {
+    it("loads AI and STT verification from secure storage", async () => {
+      const aiData = {
+        provider: "openai",
+        model: "gpt-4",
+        apiKeyHash: "abc123",
+        verifiedAt: Date.now(),
+        isVerified: true,
+      };
+      secureStorageData["secure_ai_verification"] = JSON.stringify(aiData);
+
+      await loadVerificationCache();
+
+      const result = getAIVerificationStatus();
+      expect(result).toEqual(aiData);
+    });
+
+    it("handles empty secure storage", async () => {
+      await loadVerificationCache();
+
+      expect(getAIVerificationStatus()).toBeNull();
+      expect(getSTTVerificationStatus()).toBeNull();
+    });
+
+    it("handles JSON parse errors gracefully", async () => {
+      secureStorageData["secure_ai_verification"] = "invalid json";
+
+      await loadVerificationCache();
+
+      expect(getAIVerificationStatus()).toBeNull();
+    });
+  });
+
+  describe("migrateVerificationToSecureStorage", () => {
+    it("migrates AI verification from localStorage to secure storage", async () => {
+      const data = {
+        provider: "openai",
+        model: "gpt-4",
+        apiKeyHash: "hash123",
+        verifiedAt: Date.now(),
+        isVerified: true,
+      };
+      localStorageData[STORAGE_KEYS.AI_PROVIDER_VERIFIED] = JSON.stringify(data);
+
+      await migrateVerificationToSecureStorage();
+
+      expect(secureSet).toHaveBeenCalledWith(
+        "secure_ai_verification",
+        JSON.stringify(data)
+      );
+      expect(localStorageData[STORAGE_KEYS.AI_PROVIDER_VERIFIED]).toBeUndefined();
+    });
+
+    it("migrates STT verification from localStorage to secure storage", async () => {
+      const data = {
+        provider: "whisper",
+        model: "whisper-1",
+        apiKeyHash: "hash456",
+        verifiedAt: Date.now(),
+        isVerified: true,
+      };
+      localStorageData[STORAGE_KEYS.STT_PROVIDER_VERIFIED] = JSON.stringify(data);
+
+      await migrateVerificationToSecureStorage();
+
+      expect(secureSet).toHaveBeenCalledWith(
+        "secure_stt_verification",
+        JSON.stringify(data)
+      );
+      expect(localStorageData[STORAGE_KEYS.STT_PROVIDER_VERIFIED]).toBeUndefined();
+    });
+
+    it("does not overwrite existing secure storage data", async () => {
+      secureStorageData["secure_ai_verification"] = JSON.stringify({
+        provider: "existing",
+        isVerified: true,
+      });
+      localStorageData[STORAGE_KEYS.AI_PROVIDER_VERIFIED] = JSON.stringify({
+        provider: "local",
+        isVerified: true,
+      });
+
+      await migrateVerificationToSecureStorage();
+
+      // Should NOT have overwritten secure storage
+      expect(secureSet).not.toHaveBeenCalledWith(
+        "secure_ai_verification",
+        expect.any(String)
+      );
+      // But should still remove from localStorage
+      expect(localStorageData[STORAGE_KEYS.AI_PROVIDER_VERIFIED]).toBeUndefined();
+    });
+  });
+
+  describe("getAIVerificationStatus / getSTTVerificationStatus", () => {
+    it("returns null when cache not loaded", () => {
+      // Cache is reset in beforeEach, so should return null
+      expect(getAIVerificationStatus()).toBeNull();
+      expect(getSTTVerificationStatus()).toBeNull();
+    });
+
+    it("returns cached verification data after load", async () => {
+      const data = {
+        provider: "openai",
+        model: "gpt-4",
+        apiKeyHash: "abc123",
+        verifiedAt: Date.now(),
+        isVerified: true,
+      };
+      secureStorageData["secure_ai_verification"] = JSON.stringify(data);
+
+      await loadVerificationCache();
+
+      expect(getAIVerificationStatus()).toEqual(data);
+    });
+  });
+
+  describe("setAIVerificationStatus / setSTTVerificationStatus", () => {
+    it("stores verification status in secure storage with hashed API key", async () => {
+      await setAIVerificationStatus("openai", "gpt-4", "sk-test-key", true);
+
+      expect(secureSet).toHaveBeenCalledWith(
+        "secure_ai_verification",
+        expect.any(String)
+      );
+
+      const stored = JSON.parse(secureStorageData["secure_ai_verification"]);
+      expect(stored.provider).toBe("openai");
+      expect(stored.model).toBe("gpt-4");
+      expect(stored.isVerified).toBe(true);
+      expect(stored.apiKeyHash).toBeDefined();
+      expect(stored.apiKeyHash).not.toBe("sk-test-key"); // Should be hashed
+    });
+
+    it("updates cache immediately", async () => {
+      await setAIVerificationStatus("openai", "gpt-4", "sk-test-key", true);
+
+      const cached = getAIVerificationStatus();
+      expect(cached?.provider).toBe("openai");
+      expect(cached?.isVerified).toBe(true);
+    });
+
+    it("stores error message when verification fails", async () => {
+      await setAIVerificationStatus("openai", "gpt-4", "bad-key", false, "Invalid API key");
+
+      const cached = getAIVerificationStatus();
+      expect(cached?.isVerified).toBe(false);
+      expect(cached?.errorMessage).toBe("Invalid API key");
+    });
+
+    it("stores STT verification separately from AI", async () => {
+      await setAIVerificationStatus("openai", "gpt-4", "ai-key", true);
+      await setSTTVerificationStatus("whisper", "whisper-1", "stt-key", true);
+
+      expect(secureStorageData["secure_ai_verification"]).toBeDefined();
+      expect(secureStorageData["secure_stt_verification"]).toBeDefined();
+
+      const aiCached = getAIVerificationStatus();
+      const sttCached = getSTTVerificationStatus();
+
+      expect(aiCached?.provider).toBe("openai");
+      expect(sttCached?.provider).toBe("whisper");
+    });
+  });
+
+  describe("clearAIVerificationStatus / clearSTTVerificationStatus", () => {
+    it("clears AI verification from cache and secure storage", async () => {
+      await setAIVerificationStatus("openai", "gpt-4", "key", true);
+      expect(getAIVerificationStatus()).not.toBeNull();
+
+      await clearAIVerificationStatus();
+
+      expect(getAIVerificationStatus()).toBeNull();
+      expect(secureDelete).toHaveBeenCalledWith("secure_ai_verification");
+    });
+
+    it("clears STT verification from cache and secure storage", async () => {
+      await setSTTVerificationStatus("whisper", "whisper-1", "key", true);
+      expect(getSTTVerificationStatus()).not.toBeNull();
+
+      await clearSTTVerificationStatus();
+
+      expect(getSTTVerificationStatus()).toBeNull();
+      expect(secureDelete).toHaveBeenCalledWith("secure_stt_verification");
+    });
+  });
+
+  describe("isAIVerificationValid / isSTTVerificationValid - Hash Invalidation", () => {
+    it("returns true when provider, model, and API key match", async () => {
+      await setAIVerificationStatus("openai", "gpt-4", "sk-test-key", true);
+
+      const isValid = await isAIVerificationValid("openai", "gpt-4", "sk-test-key");
+      expect(isValid).toBe(true);
+    });
+
+    it("returns false when no verification exists", async () => {
+      const isValid = await isAIVerificationValid("openai", "gpt-4", "sk-test-key");
+      expect(isValid).toBe(false);
+    });
+
+    it("returns false when verification failed", async () => {
+      await setAIVerificationStatus("openai", "gpt-4", "sk-test-key", false, "Error");
+
+      const isValid = await isAIVerificationValid("openai", "gpt-4", "sk-test-key");
+      expect(isValid).toBe(false);
+    });
+
+    it("INVALIDATES when provider changes", async () => {
+      await setAIVerificationStatus("openai", "gpt-4", "sk-test-key", true);
+
+      // Same model and key, different provider
+      const isValid = await isAIVerificationValid("anthropic", "gpt-4", "sk-test-key");
+      expect(isValid).toBe(false);
+    });
+
+    it("INVALIDATES when model changes", async () => {
+      await setAIVerificationStatus("openai", "gpt-4", "sk-test-key", true);
+
+      // Same provider and key, different model
+      const isValid = await isAIVerificationValid("openai", "gpt-4-turbo", "sk-test-key");
+      expect(isValid).toBe(false);
+    });
+
+    it("INVALIDATES when API key changes", async () => {
+      await setAIVerificationStatus("openai", "gpt-4", "sk-test-key-1", true);
+
+      // Same provider and model, different key
+      const isValid = await isAIVerificationValid("openai", "gpt-4", "sk-test-key-2");
+      expect(isValid).toBe(false);
+    });
+
+    it("validates STT verification independently", async () => {
+      await setSTTVerificationStatus("groq", "whisper-large-v3", "stt-key", true);
+
+      const isValid = await isSTTVerificationValid("groq", "whisper-large-v3", "stt-key");
+      expect(isValid).toBe(true);
+
+      // Different key should invalidate
+      const isInvalid = await isSTTVerificationValid("groq", "whisper-large-v3", "different-key");
+      expect(isInvalid).toBe(false);
+    });
+  });
+
+  describe("getAIVerificationError / getSTTVerificationError", () => {
+    it("returns error message when verification failed", async () => {
+      await setAIVerificationStatus("openai", "gpt-4", "key", false, "Rate limit exceeded");
+
+      expect(getAIVerificationError()).toBe("Rate limit exceeded");
+    });
+
+    it("returns undefined when no error", async () => {
+      await setAIVerificationStatus("openai", "gpt-4", "key", true);
+
+      expect(getAIVerificationError()).toBeUndefined();
+    });
+
+    it("returns undefined when no verification exists", () => {
+      expect(getAIVerificationError()).toBeUndefined();
+      expect(getSTTVerificationError()).toBeUndefined();
+    });
+  });
+
+  describe("SHA-256 Hashing", () => {
+    it("uses crypto.subtle.digest for hashing", async () => {
+      await setAIVerificationStatus("openai", "gpt-4", "my-api-key", true);
+
+      // TextEncoder.encode() returns Uint8Array, which is passed to crypto.subtle.digest
+      expect(mockDigest).toHaveBeenCalledWith("SHA-256", expect.any(Uint8Array));
+    });
+
+    it("produces empty hash for empty API key", async () => {
+      await setAIVerificationStatus("openai", "gpt-4", "", true);
+
+      const cached = getAIVerificationStatus();
+      expect(cached?.apiKeyHash).toBe("");
+    });
+
+    it("produces consistent hashes for same input", async () => {
+      await setAIVerificationStatus("openai", "gpt-4", "consistent-key", true);
+      const hash1 = getAIVerificationStatus()?.apiKeyHash;
+
+      await setAIVerificationStatus("openai", "gpt-4", "consistent-key", true);
+      const hash2 = getAIVerificationStatus()?.apiKeyHash;
+
+      expect(hash1).toBe(hash2);
+    });
+
+    it("produces different hashes for different inputs", async () => {
+      await setAIVerificationStatus("openai", "gpt-4", "key-one", true);
+      const hash1 = getAIVerificationStatus()?.apiKeyHash;
+
+      await setAIVerificationStatus("openai", "gpt-4", "key-two", true);
+      const hash2 = getAIVerificationStatus()?.apiKeyHash;
+
+      expect(hash1).not.toBe(hash2);
+    });
+  });
+
+  describe("Edge Cases", () => {
+    it("handles empty model name", async () => {
+      await setAIVerificationStatus("openai", "", "key", true);
+      const isValid = await isAIVerificationValid("openai", "", "key");
+      expect(isValid).toBe(true);
+    });
+
+    it("handles special characters in API key", async () => {
+      const specialKey = "sk-proj-ABC123!@#$%^&*()_+-=[]{}|;':\",./<>?";
+      await setAIVerificationStatus("openai", "gpt-4", specialKey, true);
+
+      const isValid = await isAIVerificationValid("openai", "gpt-4", specialKey);
+      expect(isValid).toBe(true);
+    });
+
+    it("handles unicode in model name", async () => {
+      await setAIVerificationStatus("openai", "gpt-4-日本語", "key", true);
+      const isValid = await isAIVerificationValid("openai", "gpt-4-日本語", "key");
+      expect(isValid).toBe(true);
+    });
+
+    it("handles very long API keys", async () => {
+      const longKey = "sk-" + "a".repeat(1000);
+      await setAIVerificationStatus("openai", "gpt-4", longKey, true);
+
+      const isValid = await isAIVerificationValid("openai", "gpt-4", longKey);
+      expect(isValid).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- **Rename "Dev Space" to "API Setup"** for better clarity on the page's purpose
- **Add API verification checkbox** that tests AI/STT connections before unlocking the app
- **Implement per-provider configuration storage** - API keys now persist when switching between providers (e.g., OpenAI → Groq → back to OpenAI keeps your OpenAI key)
- **Add setup progress header** showing 4-step completion status (AI configured, AI verified, STT configured, STT verified)
- **Grey out menu items** until setup is complete
- **Redirect to API Setup page** when providers are not configured/verified
- **Show "Setup Required" message** in main overlay when not configured

## New Files

| File | Purpose |
|------|---------|
| `src/components/ProviderVerification/index.tsx` | Checkbox component for testing API connections |
| `src/hooks/useSetupStatus.ts` | Hook for tracking setup completion status |
| `src/lib/storage/verification.storage.ts` | Storage helpers for verification status |
| `src/lib/functions/api-test.function.ts` | Functions for testing AI/STT provider connections |
| `src/pages/dev/components/SetupProgressHeader.tsx` | Progress header showing setup completion |

## Test plan

- [ ] Select an AI provider (e.g., OpenAI), enter API key, select model
- [ ] Click verification checkbox - should test connection and show success/failure
- [ ] Switch to another provider (e.g., Groq), enter different API key
- [ ] Switch back to OpenAI - API key and model should be preserved
- [ ] Verify the app is locked until both AI and STT are configured and verified
- [ ] Verify the setup progress header updates correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)