### PR TITLE
feat: add enhanced meeting mock data and SummaryList refinements

### DIFF
--- a/src/lib/mock-data/enhanced-meeting-mock.ts
+++ b/src/lib/mock-data/enhanced-meeting-mock.ts
@@ -3,12 +3,13 @@
 //
 // SCAFFOLDING — not yet wired into the app. Feeds the upcoming context-memory
 // enhancement (titles, durations, action-item status, knowledge profile).
-// TODO(context-memory): consume via SummaryList `mockSummaries` prop, and once
-// the real KnowledgeEntity/action-item DB schema lands, replace MockActionItem /
-// MOCK_KNOWLEDGE_PROFILE with the canonical types in @/types so the compiler
-// keeps them in sync. Remove this file when the feature ships.
+// TODO(context-memory): consume via SummaryList `mockSummaries` prop. Summaries
+// and the knowledge profile are annotated against the canonical @/types so the
+// compiler flags drift. MockActionItem stays local: the richer per-item shape
+// (priority/status/dueDate) has no canonical equivalent yet — the real @/types
+// ActionItem is minimal ({ text, assignee?, status }). Remove when feature ships.
 
-import type { MeetingSummary } from "@/types";
+import type { MeetingSummary, KnowledgeProfile } from "@/types";
 
 // Mock enhanced meeting summary data
 export const MOCK_ENHANCED_SUMMARIES: MeetingSummary[] = [
@@ -244,7 +245,7 @@ export const MOCK_ACTION_ITEMS: Record<string, MockActionItem[]> = {
 };
 
 // Mock enhanced knowledge profile
-export const MOCK_KNOWLEDGE_PROFILE = {
+export const MOCK_KNOWLEDGE_PROFILE: KnowledgeProfile = {
   id: "profile",
   summary: "Working on Q1 product launch with focus on dark mode feature, API v2 migration, and enterprise client onboarding. Leading a team of 5 engineers and collaborating with design and marketing teams.",
   keyPeople: [
@@ -284,6 +285,5 @@ export const MOCK_KNOWLEDGE_PROFILE = {
     "Team velocity increased by 15% this sprint",
   ],
   lastCompacted: Date.now(),
-  lastFiltered: Date.now(),
   sourceCount: 3,
 };

--- a/src/lib/mock-data/enhanced-meeting-mock.ts
+++ b/src/lib/mock-data/enhanced-meeting-mock.ts
@@ -1,0 +1,282 @@
+// Mock data for enhanced meeting summaries UI
+// This demonstrates the new features from the website screenshots
+
+import type { MeetingSummary } from "@/types";
+
+// Mock enhanced meeting summary data
+export const MOCK_ENHANCED_SUMMARIES: MeetingSummary[] = [
+  {
+    id: "mock-1",
+    conversationId: "conv-1",
+    title: "Product Roadmap Planning", // NEW: Auto-generated title
+    summary: "Discussed Q1 product priorities, decided to prioritize dark mode feature for next sprint, and planned beta program launch with 50 early users. Team aligned on API v2 migration timeline for Q2 2026.",
+    topics: ["Product Strategy", "Sprint Planning", "API Migration"],
+    actionItems: [
+      "Sarah: Design dark mode mockups by Friday",
+      "John: Draft beta program requirements",
+      "Team: Review competitor analysis doc"
+    ],
+    nextSteps: [ // NEW: Separate from action items
+      "Schedule follow-up for Monday 10am",
+      "Share summary with stakeholders"
+    ],
+    decisions: [
+      "Prioritize dark mode feature for next sprint",
+      "Move API v2 migration to Q2 2026",
+      "Launch beta program with 50 early users"
+    ],
+    participants: ["Sarah", "John", "Emma", "Michael"],
+    goals: [ // NEW: Goals discussed
+      "Launch new product features by end of Q1",
+      "Improve user retention by 20%",
+      "Complete API v2 migration by Q2"
+    ],
+    teamUpdates: [ // NEW: Team status updates
+      "Sarah completed authentication module",
+      "Design team finished dashboard mockups",
+      "Marketing campaign performing 45% above target"
+    ],
+    exchangeCount: 24,
+    durationSeconds: 2700, // NEW: 45 minutes
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+  },
+  {
+    id: "mock-2",
+    conversationId: "conv-2",
+    title: "Client Onboarding Discussion",
+    summary: "Reviewed requirements for new enterprise client. Discussed custom branding needs, SSO integration timeline, and training schedule for their team of 200 users.",
+    topics: ["Client Onboarding", "SSO Integration", "Training"],
+    actionItems: [
+      "Alex: Prepare custom branding proposal",
+      "Sarah: Set up SSO test environment",
+      "John: Schedule training sessions"
+    ],
+    nextSteps: [
+      "Send proposal to client by EOW",
+      "Schedule kickoff call for next Tuesday"
+    ],
+    decisions: [
+      "Offer premium support tier for first 3 months",
+      "Custom branding available in 2-week timeline",
+      "SSO integration to be completed before training"
+    ],
+    participants: ["Alex", "Sarah", "John"],
+    goals: [
+      "Onboard client successfully by end of month",
+      "Ensure smooth SSO integration",
+      "Train all 200 users within 2 weeks"
+    ],
+    teamUpdates: [
+      "Alex closed 3 deals this week",
+      "Support team handling 50+ tickets daily",
+      "New developer started on Monday"
+    ],
+    exchangeCount: 18,
+    durationSeconds: 1800, // 30 minutes
+    createdAt: Date.now() - 1800000,
+    updatedAt: Date.now() - 1800000,
+  },
+  {
+    id: "mock-3",
+    conversationId: "conv-3",
+    title: "Sprint Retrospective",
+    summary: "Team reflected on completed sprint. Identified blockers with API documentation and agreed to improve code review turnaround time. Celebrated shipping dark mode feature ahead of schedule.",
+    topics: ["Retrospective", "Process Improvement", "Team Performance"],
+    actionItems: [
+      "Emma: Update API documentation by Wednesday",
+      "Michael: Set up automated code review reminders",
+      "Team: Complete anonymous feedback survey"
+    ],
+    nextSteps: [
+      "Implement improvements in next sprint",
+      "Review feedback survey results next week"
+    ],
+    decisions: [
+      "Code reviews must be completed within 24 hours",
+      "API documentation to be updated weekly",
+      "Add daily standup at 10am instead of 9am"
+    ],
+    participants: ["Emma", "Michael", "Sarah", "John", "Alex"],
+    goals: [
+      "Reduce code review cycle time to under 24 hours",
+      "Improve API documentation quality",
+      "Increase team satisfaction scores"
+    ],
+    teamUpdates: [
+      "Dark mode feature shipped ahead of schedule",
+      "Emma received engineering excellence award",
+      "Team velocity increased by 15% this sprint"
+    ],
+    exchangeCount: 32,
+    durationSeconds: 3600, // 60 minutes
+    createdAt: Date.now() - 3600000,
+    updatedAt: Date.now() - 3600000,
+  },
+];
+
+// Mock action items with assignees (for the new action_items table structure)
+export interface MockActionItem {
+  id: string;
+  summaryId: string;
+  description: string;
+  assignee: string | null;
+  priority: 'high' | 'normal' | 'low';
+  status: 'pending' | 'in_progress' | 'completed' | 'cancelled';
+  dueDate: number | null;
+  createdAt: number;
+  updatedAt: number;
+}
+
+export const MOCK_ACTION_ITEMS: Record<string, MockActionItem[]> = {
+  "mock-1": [
+    {
+      id: "action-1",
+      summaryId: "mock-1",
+      description: "Design dark mode mockups by Friday",
+      assignee: "Sarah",
+      priority: "high",
+      status: "in_progress",
+      dueDate: Date.now() + 172800000, // 2 days from now
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    },
+    {
+      id: "action-2",
+      summaryId: "mock-1",
+      description: "Draft beta program requirements",
+      assignee: "John",
+      priority: "normal",
+      status: "pending",
+      dueDate: null,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    },
+    {
+      id: "action-3",
+      summaryId: "mock-1",
+      description: "Review competitor analysis doc",
+      assignee: null, // Assigned to "Team"
+      priority: "normal",
+      status: "pending",
+      dueDate: null,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    },
+  ],
+  "mock-2": [
+    {
+      id: "action-4",
+      summaryId: "mock-2",
+      description: "Prepare custom branding proposal",
+      assignee: "Alex",
+      priority: "high",
+      status: "pending",
+      dueDate: Date.now() + 259200000, // 3 days from now
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    },
+    {
+      id: "action-5",
+      summaryId: "mock-2",
+      description: "Set up SSO test environment",
+      assignee: "Sarah",
+      priority: "high",
+      status: "pending",
+      dueDate: null,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    },
+    {
+      id: "action-6",
+      summaryId: "mock-2",
+      description: "Schedule training sessions",
+      assignee: "John",
+      priority: "normal",
+      status: "pending",
+      dueDate: null,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    },
+  ],
+  "mock-3": [
+    {
+      id: "action-7",
+      summaryId: "mock-3",
+      description: "Update API documentation by Wednesday",
+      assignee: "Emma",
+      priority: "high",
+      status: "in_progress",
+      dueDate: Date.now() + 86400000, // 1 day from now
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    },
+    {
+      id: "action-8",
+      summaryId: "mock-3",
+      description: "Set up automated code review reminders",
+      assignee: "Michael",
+      priority: "normal",
+      status: "pending",
+      dueDate: null,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    },
+    {
+      id: "action-9",
+      summaryId: "mock-3",
+      description: "Complete anonymous feedback survey",
+      assignee: null, // Team task
+      priority: "low",
+      status: "pending",
+      dueDate: Date.now() + 604800000, // 7 days from now
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    },
+  ],
+};
+
+// Mock enhanced knowledge profile
+export const MOCK_KNOWLEDGE_PROFILE = {
+  id: "profile",
+  summary: "Working on Q1 product launch with focus on dark mode feature, API v2 migration, and enterprise client onboarding. Leading a team of 5 engineers and collaborating with design and marketing teams.",
+  keyPeople: [
+    { name: "Sarah", role: "Senior Engineer", relationship: "Tech lead on authentication and dark mode" },
+    { name: "John", role: "Product Manager", relationship: "Coordinates roadmap and beta program" },
+    { name: "Emma", role: "Engineering Manager", relationship: "Manages team velocity and process improvements" },
+    { name: "Alex", role: "Sales Lead", relationship: "Handles enterprise client relationships" },
+  ],
+  keyProjects: [
+    { name: "Dark Mode Feature", status: "active", description: "User-requested feature for Q1 launch" },
+    { name: "API v2 Migration", status: "planning", description: "Major infrastructure upgrade planned for Q2" },
+    { name: "Beta Program", status: "active", description: "50 early users testing new features" },
+  ],
+  terminology: [
+    { term: "SSO", meaning: "Single Sign-On authentication integration" },
+    { term: "Code review turnaround", meaning: "Time from PR submission to approval" },
+  ],
+  recentGoals: [
+    "Launch new product features by end of Q1",
+    "Improve user retention by 20%",
+    "Onboard enterprise client with 200 users",
+    "Reduce code review cycle time to under 24 hours",
+  ],
+  recentDecisions: [
+    "Prioritize dark mode feature for next sprint",
+    "Move API v2 migration to Q2 2026",
+    "Launch beta program with 50 early users",
+    "Code reviews must be completed within 24 hours",
+    "Offer premium support tier for enterprise client",
+  ],
+  recentTeamUpdates: [
+    "Sarah completed authentication module",
+    "Design team finished dashboard mockups",
+    "Marketing campaign performing 45% above target",
+    "Dark mode feature shipped ahead of schedule",
+    "Emma received engineering excellence award",
+    "Team velocity increased by 15% this sprint",
+  ],
+  lastCompacted: Date.now(),
+  lastFiltered: Date.now(),
+  sourceCount: 3,
+};

--- a/src/lib/mock-data/enhanced-meeting-mock.ts
+++ b/src/lib/mock-data/enhanced-meeting-mock.ts
@@ -1,5 +1,12 @@
 // Mock data for enhanced meeting summaries UI
 // This demonstrates the new features from the website screenshots
+//
+// SCAFFOLDING — not yet wired into the app. Feeds the upcoming context-memory
+// enhancement (titles, durations, action-item status, knowledge profile).
+// TODO(context-memory): consume via SummaryList `mockSummaries` prop, and once
+// the real KnowledgeEntity/action-item DB schema lands, replace MockActionItem /
+// MOCK_KNOWLEDGE_PROFILE with the canonical types in @/types so the compiler
+// keeps them in sync. Remove this file when the feature ships.
 
 import type { MeetingSummary } from "@/types";
 

--- a/src/pages/context-memory/components/SummaryList.tsx
+++ b/src/pages/context-memory/components/SummaryList.tsx
@@ -85,6 +85,9 @@ export const SummaryList = ({
 
   const formatDuration = (seconds: number): string => {
     const minutes = Math.floor(seconds / 60);
+    if (minutes < 1) {
+      return `${Math.max(0, Math.round(seconds))}s`;
+    }
     if (minutes < 60) {
       return `${minutes}min`;
     }

--- a/src/pages/context-memory/components/SummaryList.tsx
+++ b/src/pages/context-memory/components/SummaryList.tsx
@@ -16,12 +16,14 @@ interface SummaryListProps {
   onSelectSummary: (summary: MeetingSummary) => void;
   selectedSummaryId?: string;
   refreshTrigger?: number;
+  mockSummaries?: MeetingSummary[]; // Optional mock data for UI mockup
 }
 
 export const SummaryList = ({
   onSelectSummary,
   selectedSummaryId,
   refreshTrigger,
+  mockSummaries,
 }: SummaryListProps) => {
   const [summaries, setSummaries] = useState<MeetingSummary[]>([]);
   const [loading, setLoading] = useState(true);
@@ -30,8 +32,13 @@ export const SummaryList = ({
   const loadSummaries = async () => {
     setLoading(true);
     try {
-      const data = await getAllMeetingSummaries();
-      setSummaries(data);
+      // Use mock data if provided, otherwise load from database
+      if (mockSummaries) {
+        setSummaries(mockSummaries);
+      } else {
+        const data = await getAllMeetingSummaries();
+        setSummaries(data);
+      }
     } catch (error) {
       console.error("Failed to load summaries:", error);
     } finally {
@@ -41,7 +48,7 @@ export const SummaryList = ({
 
   useEffect(() => {
     loadSummaries();
-  }, [refreshTrigger]);
+  }, [refreshTrigger, mockSummaries]);
 
   const handleDelete = async (e: React.MouseEvent, id: string) => {
     e.stopPropagation();
@@ -72,6 +79,16 @@ export const SummaryList = ({
       hour: "2-digit",
       minute: "2-digit",
     });
+  };
+
+  const formatDuration = (seconds: number): string => {
+    const minutes = Math.floor(seconds / 60);
+    if (minutes < 60) {
+      return `${minutes}min`;
+    }
+    const hours = Math.floor(minutes / 60);
+    const remainingMinutes = minutes % 60;
+    return `${hours}h${remainingMinutes > 0 ? ` ${remainingMinutes}m` : ''}`;
   };
 
   if (loading) {
@@ -136,18 +153,33 @@ export const SummaryList = ({
               >
                 <div className="flex items-start justify-between gap-2">
                   <div className="flex-1 min-w-0">
-                    <div className="flex items-center gap-2 mb-1">
+                    {/* Meeting Title */}
+                    {(summary as any).title && (
+                      <h4 className="text-sm font-semibold mb-1 line-clamp-1">
+                        {(summary as any).title}
+                      </h4>
+                    )}
+
+                    {/* Metadata with duration */}
+                    <div className="flex items-center gap-2 mb-1 flex-wrap">
+                      {(summary as any).durationSeconds && (summary as any).durationSeconds > 0 && (
+                        <Badge variant="outline" className="text-xs">
+                          {formatDuration((summary as any).durationSeconds)}
+                        </Badge>
+                      )}
+                      {summary.participants && summary.participants.length > 0 && (
+                        <Badge variant="outline" className="text-xs">
+                          {summary.participants.length} participant{summary.participants.length !== 1 ? 's' : ''}
+                        </Badge>
+                      )}
                       <span className="text-xs text-muted-foreground">
                         {formatDate(summary.createdAt)}
                       </span>
                       <span className="text-xs text-muted-foreground">
                         {formatTime(summary.createdAt)}
                       </span>
-                      <Badge variant="outline" className="text-xs">
-                        {summary.exchangeCount} exchanges
-                      </Badge>
                     </div>
-                    <p className="text-sm line-clamp-2">{summary.summary}</p>
+                    <p className="text-sm text-muted-foreground line-clamp-2">{summary.summary}</p>
                     {summary.topics.length > 0 && (
                       <div className="flex flex-wrap gap-1 mt-2">
                         {summary.topics.slice(0, 3).map((topic, i) => (

--- a/src/pages/context-memory/components/SummaryList.tsx
+++ b/src/pages/context-memory/components/SummaryList.tsx
@@ -16,7 +16,9 @@ interface SummaryListProps {
   onSelectSummary: (summary: MeetingSummary) => void;
   selectedSummaryId?: string;
   refreshTrigger?: number;
-  mockSummaries?: MeetingSummary[]; // Optional mock data for UI mockup
+  // SCAFFOLDING: optional mock data for UI mockup, not yet passed by any caller.
+  // TODO(context-memory): wire from index.tsx using MOCK_ENHANCED_SUMMARIES.
+  mockSummaries?: MeetingSummary[];
 }
 
 export const SummaryList = ({
@@ -154,17 +156,17 @@ export const SummaryList = ({
                 <div className="flex items-start justify-between gap-2">
                   <div className="flex-1 min-w-0">
                     {/* Meeting Title */}
-                    {(summary as any).title && (
+                    {summary.title && (
                       <h4 className="text-sm font-semibold mb-1 line-clamp-1">
-                        {(summary as any).title}
+                        {summary.title}
                       </h4>
                     )}
 
                     {/* Metadata with duration */}
                     <div className="flex items-center gap-2 mb-1 flex-wrap">
-                      {(summary as any).durationSeconds && (summary as any).durationSeconds > 0 && (
+                      {summary.durationSeconds && summary.durationSeconds > 0 && (
                         <Badge variant="outline" className="text-xs">
-                          {formatDuration((summary as any).durationSeconds)}
+                          {formatDuration(summary.durationSeconds)}
                         </Badge>
                       )}
                       {summary.participants && summary.participants.length > 0 && (


### PR DESCRIPTION
## Summary
Salvages the two non-duplicate files from pre-sync local work after `main` was synced with `origin/main` (which included PR #14).

- **`src/lib/mock-data/enhanced-meeting-mock.ts`** — new mock dataset for context-memory/summary development. Aligned to the current `MeetingSummary` type (removed `startedAt`/`endedAt` fields that existed only in a divergent local type version).
- **`src/pages/context-memory/components/SummaryList.tsx`** — refinements not covered by PR #14.

## Context
Local `main` had ~19 files of uncommitted divergent work. 17 of those overlapped with work already merged via PR #14 (editors, checkbox, v7 migration, KnowledgeProfileCard, SummaryDetail, etc.) — those were dropped in favor of the merged canonical versions. Only these 2 files were genuinely unique and are preserved here.

## Verification
- `npx tsc --noEmit` → 0 errors project-wide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)