### PR TITLE
Update Anthropic models to current lineup

### DIFF
--- a/postcss.config.mjs
+++ b/postcss.config.mjs
@@ -1,0 +1,5 @@
+// Tailwind v4 is handled by the @tailwindcss/vite plugin (see vite.config.ts),
+// so PostCSS needs no plugins here. This empty config exists to stop PostCSS
+// from walking up the directory tree and picking up an unrelated parent-level
+// postcss.config.js (which can pull in an incompatible Tailwind v3).
+export default {};

--- a/src/config/ai-providers.constants.ts
+++ b/src/config/ai-providers.constants.ts
@@ -22,7 +22,7 @@ export const AI_PROVIDERS = [
     "model": "{{MODEL}}",
     "system": "{{SYSTEM_PROMPT}}",
     "messages": [{"role": "user", "content": [{"type": "text", "text": "{{TEXT}}"}, {"type": "image", "source": {"type": "base64", "media_type": "image/png", "data": "{{IMAGE}}"}}]}],
-    "max_tokens": 1024
+    "max_tokens": 4096
   }'`,
     responseContentPath: "content[0].text",
     streaming: true,

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -82,9 +82,23 @@ export const MEETING_ASSIST_QUICK_ACTIONS = [
 ];
 
 // Meeting Assist system prompt for contextual insights
-export const MEETING_ASSIST_SYSTEM_PROMPT = `You are a meeting assistant providing real-time insights. The meeting transcript includes speaker labels where "You" refers to the user and other labels are meeting participants. Based on the transcript, give helpful, concise suggestions. Focus on:
-- Being practical and actionable
-- Keeping responses brief (2-3 sentences max unless more detail is needed)
-- Understanding the context and flow of the conversation
-- Distinguishing between what the user said versus what participants said
-- Providing relevant insights based on the specific request`;
+export const MEETING_ASSIST_SYSTEM_PROMPT = `You are a live meeting/interview assistant feeding the user answers in real time. The transcript uses speaker labels: "You" is the user; other labels are the other participants.
+
+ANSWER THE LATEST QUESTION:
+Always respond to the MOST RECENT thing the other participant said (shown under "MOST RECENT thing said to you") — that is the current question. Do NOT answer an earlier question that was already addressed in the conversation history. If the latest line is a fresh question, that is the one to answer.
+
+CRITICAL OUTPUT RULE:
+When the request is "What should I say?" (or any request for what the user should say/reply/respond), output ONLY the exact words the user should speak, in the first person ("I..."), ready to say aloud verbatim.
+- Do NOT describe the question, name its type, or explain your reasoning.
+- Do NOT write meta-commentary like "This looks like...", "Here's a framework", "You could say...", headers, labels, bullet scaffolding, or bracketed placeholders.
+- No preamble, no sign-off. Just the spoken answer.
+
+Style for spoken answers:
+- Natural, confident, conversational — how a sharp person actually talks, not written prose.
+- Concise: usually 3-6 sentences. Long enough to be substantive, short enough to say without rambling.
+- Genuine and SPECIFIC. Reference concrete details from the transcript (the actual role, company, product, or question mentioned). Never generic filler like "great company" or "I'm passionate about this space."
+- If the transcript names the company/product/mission, weave that concrete detail in.
+
+For other requests (e.g. "Key points so far", "Suggest questions", "Action items"): be brief, practical, and actionable (2-4 short points). These may use lists.
+
+Always distinguish what the user ("You") said from what participants said.`;

--- a/src/config/models.constants.ts
+++ b/src/config/models.constants.ts
@@ -244,8 +244,8 @@ export const STT_MODELS: Record<string, ModelOption[]> = {
     { id: "gpt-4o-mini-transcribe", name: "GPT-4o Mini Transcribe", description: "Fast and affordable" },
   ],
   groq: [
-    { id: "whisper-large-v3", name: "Whisper Large V3", recommended: true, description: "Best accuracy" },
-    { id: "whisper-large-v3-turbo", name: "Whisper Large V3 Turbo", description: "Faster variant" },
+    { id: "whisper-large-v3-turbo", name: "Whisper Large V3 Turbo", recommended: true, description: "Fastest + cheapest, near-instant for live use" },
+    { id: "whisper-large-v3", name: "Whisper Large V3", description: "Best accuracy, slightly slower" },
     { id: "distil-whisper-large-v3-en", name: "Distil Whisper (English)", description: "Fast, English only" },
   ],
   "elevenlabs-stt": [

--- a/src/config/models.constants.ts
+++ b/src/config/models.constants.ts
@@ -175,10 +175,9 @@ export const AI_MODELS: Record<string, ModelOption[]> = {
     { id: "gpt-3.5-turbo", name: "GPT-3.5 Turbo", description: "Fast, cost-effective" },
   ],
   claude: [
-    { id: "claude-3-5-sonnet-20241022", name: "Claude 3.5 Sonnet", recommended: true, description: "Latest, excellent balance of speed and quality" },
-    { id: "claude-3-opus-20240229", name: "Claude 3 Opus", description: "Highest capability" },
-    { id: "claude-3-sonnet-20240229", name: "Claude 3 Sonnet", description: "Good balance" },
-    { id: "claude-3-haiku-20240307", name: "Claude 3 Haiku", description: "Fastest, most affordable" },
+    { id: "claude-opus-4-8", name: "Claude Opus 4.8", recommended: true, description: "Most capable, best reasoning — ideal for interviews" },
+    { id: "claude-sonnet-5", name: "Claude Sonnet 5", description: "Near-Opus quality, faster and cheaper" },
+    { id: "claude-haiku-4-5", name: "Claude Haiku 4.5", description: "Fastest, most affordable" },
   ],
   grok: [
     { id: "grok-2", name: "Grok 2", recommended: true, description: "Most capable xAI model" },

--- a/src/hooks/useCompletion.ts
+++ b/src/hooks/useCompletion.ts
@@ -836,6 +836,7 @@ export const useCompletion = () => {
       // Note: conversationHistory removed - using conversationHistoryRef to avoid stale closure
       selectedAIProvider,
       allAiProviders,
+      systemPrompt,
       submit,
     ]
   );

--- a/src/hooks/useCompletion.ts
+++ b/src/hooks/useCompletion.ts
@@ -1,7 +1,12 @@
 import { useState, useCallback, useRef, useEffect } from "react";
 import { useWindowResize } from "./useWindow";
 import { useGlobalShortcuts } from "@/hooks";
-import { MAX_FILES, STORAGE_KEYS, MEETING_ASSIST_SYSTEM_PROMPT } from "@/config";
+import {
+  MAX_FILES,
+  STORAGE_KEYS,
+  MEETING_ASSIST_SYSTEM_PROMPT,
+  DEFAULT_SYSTEM_PROMPT,
+} from "@/config";
 import { useApp } from "@/contexts";
 import {
   fetchAIResponse,
@@ -650,21 +655,35 @@ export const useCompletion = () => {
         return;
       }
 
+      // Resolve a speaker label for an entry ("You" = the user).
+      const labelFor = (entry: (typeof meetingTranscript)[number]) =>
+        entry.speaker?.speakerLabel ||
+        (entry.audioSource === "microphone"
+          ? "You"
+          : entry.audioSource === "system"
+          ? "Guest"
+          : null);
+
       // Build the meeting context prompt with speaker attribution
-      const meetingContext = meetingTranscript.map((entry) => {
-        // Extract speaker label with fallback logic
-        const speakerLabel = entry.speaker?.speakerLabel ||
-          (entry.audioSource === 'microphone' ? 'You' :
-           entry.audioSource === 'system' ? 'Guest' : null);
+      const meetingContext = meetingTranscript
+        .map((entry) => {
+          const speakerLabel = labelFor(entry);
+          // No speaker info - return text as-is (backwards compatible)
+          return speakerLabel ? `${speakerLabel}: ${entry.original}` : entry.original;
+        })
+        .join("\n\n");
 
-        if (speakerLabel) {
-          return `${speakerLabel}: ${entry.original}`;
-        }
+      // Find the most recent thing said by someone OTHER than the user, so the
+      // model answers the LATEST question instead of an earlier one. Fall back
+      // to the last line if we can't tell who spoke.
+      const lastParticipant =
+        [...meetingTranscript].reverse().find((e) => labelFor(e) !== "You") ??
+        meetingTranscript[meetingTranscript.length - 1];
+      const latestLine = lastParticipant
+        ? `${labelFor(lastParticipant) ?? "Them"}: ${lastParticipant.original}`
+        : "";
 
-        // No speaker info - return text as-is (backwards compatible)
-        return entry.original;
-      }).join("\n\n");
-      const contextualPrompt = `## Meeting Transcript:\n${meetingContext}\n\n## Your Request: ${action}`;
+      const contextualPrompt = `## Meeting Transcript:\n${meetingContext}\n\n## MOST RECENT thing said to you (answer THIS):\n${latestLine}\n\n## Your Request: ${action}`;
 
       // Generate unique request ID
       const requestId = generateRequestId();
@@ -726,11 +745,17 @@ export const useCompletion = () => {
           content: msg.content,
         }));
 
-        // Use Meeting Assist system prompt for better context
+        // Use Meeting Assist system prompt for better context, and fold in the
+        // user's own system prompt (their background/context) so answers are
+        // personalized. The default generic prompt adds nothing, so skip it.
+        const userContext =
+          systemPrompt && systemPrompt !== DEFAULT_SYSTEM_PROMPT
+            ? `\n\nAbout the user (use this to make answers specific and in their voice):\n${systemPrompt}`
+            : "";
         for await (const chunk of fetchAIResponse({
           provider: useMeetwingsAPI ? undefined : provider,
           selectedProvider: selectedAIProvider,
-          systemPrompt: MEETING_ASSIST_SYSTEM_PROMPT,
+          systemPrompt: MEETING_ASSIST_SYSTEM_PROMPT + userContext,
           history: messageHistory,
           userMessage: contextualPrompt,
           signal,

--- a/src/lib/functions/ai-response.function.ts
+++ b/src/lib/functions/ai-response.function.ts
@@ -299,9 +299,12 @@ export async function* fetchAIResponse(params: {
         } else {
           bodyObj.stream = true;
         }
-        // Request usage data in streaming response (OpenAI-compatible APIs)
-        // This makes OpenAI include token usage in the final chunk
-        bodyObj.stream_options = { include_usage: true };
+        // Request usage data in streaming response (OpenAI-compatible APIs).
+        // Anthropic rejects stream_options (400) and returns usage natively in
+        // its message_delta events, so only send it to non-Anthropic endpoints.
+        if (!url.includes("anthropic.com")) {
+          bodyObj.stream_options = { include_usage: true };
+        }
       }
     }
 

--- a/src/lib/functions/ai-response.function.ts
+++ b/src/lib/functions/ai-response.function.ts
@@ -302,7 +302,11 @@ export async function* fetchAIResponse(params: {
         // Request usage data in streaming response (OpenAI-compatible APIs).
         // Anthropic rejects stream_options (400) and returns usage natively in
         // its message_delta events, so only send it to non-Anthropic endpoints.
-        if (!url.includes("anthropic.com")) {
+        // Detect Anthropic by both provider identity (built-in "claude") and
+        // URL host, so custom providers/proxies pointing at Anthropic are covered.
+        const isAnthropic =
+          provider?.id === "claude" || url.includes("anthropic.com");
+        if (!isAnthropic) {
           bodyObj.stream_options = { include_usage: true };
         }
       }

--- a/src/lib/storage/pricing.storage.ts
+++ b/src/lib/storage/pricing.storage.ts
@@ -18,6 +18,10 @@ export const DEFAULT_PRICING: PricingConfig = {
     "*": { inputPer1k: 0.002, outputPer1k: 0.008 }, // Default for unknown OpenAI models
   },
   claude: {
+    // Current models (per 1M: opus $5/$25, sonnet $3/$15, haiku $1/$5)
+    "claude-opus-4-8": { inputPer1k: 0.005, outputPer1k: 0.025 },
+    "claude-sonnet-5": { inputPer1k: 0.003, outputPer1k: 0.015 },
+    "claude-haiku-4-5": { inputPer1k: 0.001, outputPer1k: 0.005 },
     // Exact model IDs used in API
     "claude-3-5-sonnet-20241022": { inputPer1k: 0.003, outputPer1k: 0.015 },
     "claude-3-opus-20240229": { inputPer1k: 0.015, outputPer1k: 0.075 },


### PR DESCRIPTION
## Summary
Anthropic provider pointed at retired Claude 3 models — the API now 404s them. Updated to the current lineup, and while wiring up live interview use, refined the meeting-assist behavior and fixed two related bugs.

## Changes

### Model lineup + cost tracking
- **`models.constants.ts`** — replace dead Claude 3 models with `claude-opus-4-8` (recommended), `claude-sonnet-5`, `claude-haiku-4-5`; also make Groq `whisper-large-v3-turbo` the recommended STT model (fastest + cheapest for live use)
- **`ai-providers.constants.ts`** — Claude `max_tokens` 1024 → 4096 (1024 truncated responses mid-sentence)
- **`pricing.storage.ts`** — add per-token pricing for the new models (opus $5/$25, sonnet $3/$15, haiku $1/$5 per 1M) so cost tracking is accurate instead of using the wildcard fallback

### Meeting-assist behavior (materially changes generated responses)
- **`constants.ts`** — rewrite `MEETING_ASSIST_SYSTEM_PROMPT`: answer the MOST RECENT participant line verbatim in first person for "What should I say?", no meta-commentary
- **`useCompletion.ts`** — target the latest participant line as the current question; fold the user's own system prompt in as personal context; add `systemPrompt` to the `submitWithMeetingContext` deps array (was a stale closure — edits to the user prompt didn't take effect)

### Bug fixes
- **`ai-response.function.ts`** — only send `stream_options` to non-Anthropic endpoints (Anthropic 400s on it). Detect Anthropic by `provider.id === "claude"` OR `anthropic.com` URL, so custom Anthropic proxies/gateways are also covered
- **`postcss.config.mjs`** — pin the local PostCSS/Tailwind config so the dev server stops picking up a parent-level Tailwind v3

## Test plan
- [ ] Restart dev server, open Dev Space, confirm new Claude models appear in dropdown
- [ ] Select Anthropic + Opus 4.8, add API key, send a message — verify response completes (no mid-sentence truncation)
- [ ] Check Cost Tracking shows non-zero, correct cost
- [ ] Meeting Assist: with a multi-line transcript, "What should I say?" answers the latest participant line verbatim in first person
- [ ] Edit the user system prompt mid-session — confirm the next meeting-assist answer reflects it (stale-closure fix)
- [ ] Groq STT: select `whisper-large-v3-turbo`, confirm transcription works

🤖 Generated with [Claude Code](https://claude.com/claude-code)