### PR TITLE
ci: add Read/Grep/Glob to Claude review allowed-tools

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -53,5 +53,5 @@ jobs:
 
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
-          claude_args: '--allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
+          claude_args: '--allowed-tools "Read,Grep,Glob,Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
 


### PR DESCRIPTION
## Problem

The PR-review agent only had `gh` subcommands in `--allowed-tools` — no file-navigation tools (`Read`, `Grep`, `Glob`). On small PRs it gets by using `gh pr diff`. On large PRs it can't navigate the code, tries `Read`/`Grep` anyway, and racks up permission denials (**51** on the ~5,600-line PR #19 merge), exhausting its turn budget before it posts a review. Result: the run reports `success` but **no comment is posted**.

Evidence: reviews posted fine on PRs #15–#18 (small diffs) but PR #19 (33 files, +4,711 lines) got zero.

## Fix

Add `Read,Grep,Glob` to the review workflow's `--allowed-tools` so the agent can navigate the checked-out PR files directly instead of relying solely on one giant `gh pr diff`.

## Why a standalone PR to `main`

`claude-code-action` validates that the review workflow file is **identical to the version on the default branch**, as a security measure (a PR must not be able to edit its own reviewer). So this change only takes effect once it's merged to `main` — it cannot be applied or tested from within a feature PR (doing so causes that PR's review to be skipped).

## Scope

One line changed in `.github/workflows/claude-code-review.yml`. No app code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
