### PR TITLE
Auto-save meeting transcripts to chat history

### DIFF
--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -93,6 +93,11 @@ export const MEETING_ASSIST_QUICK_ACTIONS = [
   "Action items",
 ];
 
+// Number of meeting transcript segments to accumulate before auto-saving the
+// in-progress conversation to chat history. This prevents losing a whole meeting
+// if the user ends/clears the transcript without ever asking the AI a question.
+export const MEETING_TRANSCRIPT_AUTOSAVE_INTERVAL = 4;
+
 // Meeting Assist system prompt for contextual insights
 export const MEETING_ASSIST_SYSTEM_PROMPT = `You are a live meeting/interview assistant feeding the user answers in real time. The transcript uses speaker labels: "You" is the user; other labels are the other participants.
 

--- a/src/hooks/useCompletion.ts
+++ b/src/hooks/useCompletion.ts
@@ -12,6 +12,7 @@ import { useApp } from "@/contexts";
 import {
   fetchAIResponse,
   saveConversation,
+  appendMessagesToConversation,
   getConversationById,
   generateConversationTitle,
   shouldUseMeetwingsAPI,
@@ -161,6 +162,13 @@ export const useCompletion = () => {
   // periodically persist transcripts to chat history without stale closures.
   const meetingTranscriptLengthRef = useRef(0);
   const lastAutoSavedTranscriptCountRef = useRef(0);
+  // How many of conversationHistoryRef.current's messages (from the start)
+  // are already persisted for the current conversation. Lets the periodic
+  // autosave append only the new tail instead of redoing a full
+  // delete+reinsert of every message each time. Any full-rewrite save
+  // (quick action, normal submit, initial creation) advances this to cover
+  // everything it just wrote.
+  const persistedMessageCountRef = useRef(0);
   // Cached title/createdAt for the conversation currently being auto-saved, so
   // repeated autosaves don't re-read the row just to recover fields that never
   // change after the first save. Keyed by id: a mismatched/absent id means a
@@ -222,6 +230,12 @@ export const useCompletion = () => {
         if (messages.length === 0) {
           return;
         }
+        // Captured alongside messages, before any await below, so the
+        // watermark this run sets always matches what messages actually
+        // contains — not whatever the live ref has advanced to by the time
+        // the save finishes.
+        const transcriptLengthAtSnapshot = meetingTranscriptLengthRef.current;
+        const persistedCountAtSnapshot = persistedMessageCountRef.current;
 
         const conversationId =
           currentConversationIdRef.current || generateConversationId("chat");
@@ -252,19 +266,36 @@ export const useCompletion = () => {
           createdAt = existingConversation?.createdAt || Date.now();
         }
 
-        const conversation: ChatConversation = {
-          id: conversationId,
-          title,
-          messages,
-          createdAt,
-          updatedAt: Date.now(),
-        };
-
         try {
-          await saveConversation(conversation);
+          if (persistedCountAtSnapshot > 0) {
+            // Row already exists — append just the new tail instead of a
+            // full delete+reinsert, so autosave cost stays proportional to
+            // what changed rather than the whole conversation's size.
+            const newTailMessages = messages.slice(persistedCountAtSnapshot);
+            if (newTailMessages.length > 0) {
+              await appendMessagesToConversation(
+                conversationId,
+                title,
+                Date.now(),
+                newTailMessages
+              );
+            }
+          } else {
+            // First save for this conversation — need the full create/update
+            // upsert since there may be no row yet.
+            const conversation: ChatConversation = {
+              id: conversationId,
+              title,
+              messages,
+              createdAt,
+              updatedAt: Date.now(),
+            };
+            await saveConversation(conversation);
+          }
           setActiveConversationId(conversationId);
-          const savedCount = meetingTranscriptLengthRef.current;
+          const savedCount = transcriptLengthAtSnapshot;
           lastAutoSavedTranscriptCountRef.current = savedCount;
+          persistedMessageCountRef.current = messages.length;
           conversationMetaCacheRef.current = { id: conversationId, title, createdAt };
           console.log(
             `[Meeting Transcript Autosave] Saved ${savedCount} transcript segment(s) to conversation ${conversationId}`
@@ -545,6 +576,7 @@ export const useCompletion = () => {
     currentConversationIdRef.current = null;
     conversationHistoryRef.current = []; // Update ref immediately
     lastAutoSavedTranscriptCountRef.current = 0;
+    persistedMessageCountRef.current = 0;
     setState((prev) => ({
       ...prev,
       currentConversationId: null,
@@ -971,6 +1003,10 @@ export const useCompletion = () => {
           };
           const currentHistory = conversationHistoryRef.current;
           const newMessages = [...currentHistory, userMsg, assistantMsg];
+          // Captured alongside newMessages, before the write below, so the
+          // watermark matches what was actually persisted even if more
+          // transcript segments stream in while the write is in flight.
+          const transcriptLengthAtSnapshot = meetingTranscriptLengthRef.current;
 
           const conversation: ChatConversation = {
             id: conversationId,
@@ -993,7 +1029,10 @@ export const useCompletion = () => {
           }));
           // Quick-action saves already persisted any accumulated meeting
           // transcript, so advance the autosave watermark.
-          lastAutoSavedTranscriptCountRef.current = meetingTranscriptLengthRef.current;
+          lastAutoSavedTranscriptCountRef.current = transcriptLengthAtSnapshot;
+          // This was a full rewrite of every message, so all of them are now
+          // persisted — the next periodic autosave can append from here.
+          persistedMessageCountRef.current = newMessages.length;
         }
       } catch (error) {
         if (!signal?.aborted && currentRequestIdRef.current === requestId) {
@@ -1127,6 +1166,8 @@ export const useCompletion = () => {
     // Reset autosave watermark relative to any existing meeting transcript so
     // newly added segments start a fresh count toward the next auto-save.
     lastAutoSavedTranscriptCountRef.current = meetingTranscript.length;
+    // Everything in the loaded conversation is already in the DB.
+    persistedMessageCountRef.current = conversation.messages.length;
     setState((prev) => ({
       ...prev,
       currentConversationId: conversation.id,
@@ -1160,6 +1201,7 @@ export const useCompletion = () => {
     currentConversationIdRef.current = null;
     conversationHistoryRef.current = []; // Update ref immediately
     lastAutoSavedTranscriptCountRef.current = 0;
+    persistedMessageCountRef.current = 0;
     setState((prev) => ({
       ...prev,
       currentConversationId: null,
@@ -1205,6 +1247,10 @@ export const useCompletion = () => {
       // Use ref to avoid stale closure
       const currentHistory = conversationHistoryRef.current;
       const newMessages = [...currentHistory, userMsg, assistantMsg];
+      // Captured alongside newMessages, before the awaits below, so the
+      // watermark matches what was actually persisted even if more
+      // transcript segments stream in while this save is in flight.
+      const transcriptLengthAtSnapshot = meetingTranscriptLengthRef.current;
 
       // Get existing conversation if updating
       let existingConversation = null;
@@ -1247,7 +1293,10 @@ export const useCompletion = () => {
         }));
         // Normal AI saves already persisted any accumulated meeting transcript,
         // so advance the autosave watermark to avoid a redundant flush.
-        lastAutoSavedTranscriptCountRef.current = meetingTranscriptLengthRef.current;
+        lastAutoSavedTranscriptCountRef.current = transcriptLengthAtSnapshot;
+        // This was a full rewrite of every message, so all of them are now
+        // persisted — the next periodic autosave can append from here.
+        persistedMessageCountRef.current = newMessages.length;
       } catch (error) {
         console.error("Failed to save conversation:", error);
         // Show error to user

--- a/src/hooks/useCompletion.ts
+++ b/src/hooks/useCompletion.ts
@@ -174,6 +174,12 @@ export const useCompletion = () => {
   // together can't run concurrent saveConversation calls against the same
   // conversation id (which does a full delete+reinsert of messages).
   const saveQueueRef = useRef<Promise<void>>(Promise.resolve());
+  // Count of autosaves enqueued but not yet finished. Lets the periodic
+  // trigger skip queuing another save while one is already pending instead of
+  // piling up back-to-back writes during a burst of fast-arriving segments —
+  // the pending save reads conversationHistoryRef fresh when it actually runs,
+  // so it picks up whatever arrived in the meantime.
+  const pendingAutosaveCountRef = useRef(0);
 
   // Generate a readable title for a meeting transcript conversation when it is
   // first auto-saved. Falls back to a timestamped title if no user text exists.
@@ -188,64 +194,74 @@ export const useCompletion = () => {
   // the periodic autosave and the final flush when the transcript is cleared.
   // Queued (not fired directly) so concurrent triggers serialize instead of
   // racing; callers can still `await` the returned promise for the flush to
-  // actually land before proceeding.
-  const autoSaveMeetingTranscript = useCallback((transcriptCount: number) => {
+  // actually land before proceeding. Reads conversationHistoryRef and the live
+  // transcript length at execution time (not enqueue time), so the watermark
+  // it sets always reflects what was actually saved, however long it sat in
+  // the queue.
+  const autoSaveMeetingTranscript = useCallback(() => {
+    pendingAutosaveCountRef.current += 1;
+
     const run = async () => {
-      const messages = conversationHistoryRef.current;
-      if (messages.length === 0) {
-        return;
-      }
+      try {
+        const messages = conversationHistoryRef.current;
+        if (messages.length === 0) {
+          return;
+        }
 
-      const conversationId =
-        currentConversationIdRef.current || generateConversationId("chat");
-      currentConversationIdRef.current = conversationId;
+        const conversationId =
+          currentConversationIdRef.current || generateConversationId("chat");
+        currentConversationIdRef.current = conversationId;
 
-      const cachedMeta = conversationMetaCacheRef.current;
-      let title: string;
-      let createdAt: number;
+        const cachedMeta = conversationMetaCacheRef.current;
+        let title: string;
+        let createdAt: number;
 
-      if (cachedMeta && cachedMeta.id === conversationId) {
-        title = cachedMeta.title;
-        createdAt = cachedMeta.createdAt;
-      } else {
-        let existingConversation: ChatConversation | null = null;
+        if (cachedMeta && cachedMeta.id === conversationId) {
+          title = cachedMeta.title;
+          createdAt = cachedMeta.createdAt;
+        } else {
+          let existingConversation: ChatConversation | null = null;
+          try {
+            existingConversation = await getConversationById(conversationId);
+          } catch (error) {
+            console.error(
+              "[Meeting Transcript Autosave] Failed to load existing conversation:",
+              error
+            );
+          }
+
+          const firstUserMessage = messages.find((msg) => msg.role === "user");
+          title =
+            existingConversation?.title ||
+            generateMeetingTranscriptTitle(firstUserMessage?.content);
+          createdAt = existingConversation?.createdAt || Date.now();
+        }
+
+        const conversation: ChatConversation = {
+          id: conversationId,
+          title,
+          messages,
+          createdAt,
+          updatedAt: Date.now(),
+        };
+
         try {
-          existingConversation = await getConversationById(conversationId);
+          await saveConversation(conversation);
+          setActiveConversationId(conversationId);
+          const savedCount = meetingTranscriptLengthRef.current;
+          lastAutoSavedTranscriptCountRef.current = savedCount;
+          conversationMetaCacheRef.current = { id: conversationId, title, createdAt };
+          console.log(
+            `[Meeting Transcript Autosave] Saved ${savedCount} transcript segment(s) to conversation ${conversationId}`
+          );
         } catch (error) {
           console.error(
-            "[Meeting Transcript Autosave] Failed to load existing conversation:",
+            "[Meeting Transcript Autosave] Failed to save meeting transcript:",
             error
           );
         }
-
-        const firstUserMessage = messages.find((msg) => msg.role === "user");
-        title =
-          existingConversation?.title ||
-          generateMeetingTranscriptTitle(firstUserMessage?.content);
-        createdAt = existingConversation?.createdAt || Date.now();
-      }
-
-      const conversation: ChatConversation = {
-        id: conversationId,
-        title,
-        messages,
-        createdAt,
-        updatedAt: Date.now(),
-      };
-
-      try {
-        await saveConversation(conversation);
-        setActiveConversationId(conversationId);
-        lastAutoSavedTranscriptCountRef.current = transcriptCount;
-        conversationMetaCacheRef.current = { id: conversationId, title, createdAt };
-        console.log(
-          `[Meeting Transcript Autosave] Saved ${transcriptCount} transcript segment(s) to conversation ${conversationId}`
-        );
-      } catch (error) {
-        console.error(
-          "[Meeting Transcript Autosave] Failed to save meeting transcript:",
-          error
-        );
+      } finally {
+        pendingAutosaveCountRef.current -= 1;
       }
     };
 
@@ -264,11 +280,14 @@ export const useCompletion = () => {
   // assist mode, so nothing is lost if the user never asks the AI a question.
   useEffect(() => {
     if (!meetingAssistMode || meetingTranscript.length === 0) return;
+    // A save is already queued/running — it'll read the latest transcript when
+    // it executes, so don't pile on another one.
+    if (pendingAutosaveCountRef.current > 0) return;
 
     const nextThreshold =
       lastAutoSavedTranscriptCountRef.current + MEETING_TRANSCRIPT_AUTOSAVE_INTERVAL;
     if (meetingTranscript.length >= nextThreshold) {
-      autoSaveMeetingTranscript(meetingTranscript.length);
+      autoSaveMeetingTranscript();
     }
   }, [meetingAssistMode, meetingTranscript.length, autoSaveMeetingTranscript]);
 
@@ -497,13 +516,19 @@ export const useCompletion = () => {
       currentConversationIdRef.current &&
       conversationHistoryRef.current.length > 0
     ) {
-      await autoSaveMeetingTranscript(meetingTranscript.length);
+      await autoSaveMeetingTranscript();
     }
 
     setMeetingTranscript([]);
     // Also clear session speaker mapping
     setSessionSpeakerMap({});
-    // Also reset conversation when clearing meeting transcript
+    // Also reset conversation when clearing meeting transcript. Must clear the
+    // persisted active-conversation id too: autoSaveMeetingTranscript marks the
+    // conversation active on every save, and the knowledge backfill skips
+    // whatever conversation is marked active so it isn't summarized early —
+    // leaving it set would permanently exclude this meeting from "Update
+    // Knowledge" once cleared.
+    clearActiveConversationId();
     currentConversationIdRef.current = null;
     conversationHistoryRef.current = []; // Update ref immediately
     lastAutoSavedTranscriptCountRef.current = 0;
@@ -1062,7 +1087,22 @@ export const useCompletion = () => {
     selectedAIProvider
   ]);
 
-  const loadConversation = useCallback((conversation: ChatConversation) => {
+  const loadConversation = useCallback(async (conversation: ChatConversation) => {
+    // Flush any unsaved meeting transcript segments belonging to the
+    // conversation we're currently on before overwriting the refs to point at
+    // a different one — otherwise those segments are lost, and any further
+    // live transcript growth gets appended onto the newly loaded (unrelated)
+    // conversation instead.
+    const unsavedCount =
+      meetingTranscript.length - lastAutoSavedTranscriptCountRef.current;
+    if (
+      unsavedCount > 0 &&
+      currentConversationIdRef.current &&
+      conversationHistoryRef.current.length > 0
+    ) {
+      await autoSaveMeetingTranscript();
+    }
+
     // Summarize current conversation before switching
     summarizeCurrentConversation();
 
@@ -1082,7 +1122,7 @@ export const useCompletion = () => {
       error: null,
       isLoading: false,
     }));
-  }, [summarizeCurrentConversation, meetingTranscript.length]);
+  }, [summarizeCurrentConversation, meetingTranscript.length, autoSaveMeetingTranscript]);
 
   const startNewConversation = useCallback(async () => {
     // Flush any remaining unsaved meeting transcript before starting a new
@@ -1095,7 +1135,7 @@ export const useCompletion = () => {
       currentConversationIdRef.current &&
       conversationHistoryRef.current.length > 0
     ) {
-      await autoSaveMeetingTranscript(meetingTranscript.length);
+      await autoSaveMeetingTranscript();
     }
 
     // Summarize current conversation before starting new
@@ -1258,8 +1298,14 @@ export const useCompletion = () => {
 
     const handleConversationDeleted = (event: any) => {
       const deletedId = event.detail;
-      // If the currently active conversation was deleted, start a new one
+      // If the currently active conversation was deleted, start a new one.
+      // Clear the conversation refs first so startNewConversation's unsaved-
+      // transcript flush doesn't resurrect the just-deleted conversation —
+      // saveConversation upserts, and getConversationById now returns null for
+      // the deleted id, so an unguarded flush would recreate it.
       if (state.currentConversationId === deletedId) {
+        currentConversationIdRef.current = null;
+        conversationHistoryRef.current = [];
         startNewConversation();
       }
     };

--- a/src/hooks/useCompletion.ts
+++ b/src/hooks/useCompletion.ts
@@ -170,9 +170,10 @@ export const useCompletion = () => {
     title: string;
     createdAt: number;
   } | null>(null);
-  // Serializes autosave writes so two threshold crossings that fire close
-  // together can't run concurrent saveConversation calls against the same
-  // conversation id (which does a full delete+reinsert of messages).
+  // Serializes writes to the currently open conversation's row — periodic
+  // autosave, manual save, and quick-action save all funnel through this so
+  // two of them can never run concurrent saveConversation calls against the
+  // same conversation id (which does a full delete+reinsert of messages).
   const saveQueueRef = useRef<Promise<void>>(Promise.resolve());
   // Count of autosaves enqueued but not yet finished. Lets the periodic
   // trigger skip queuing another save while one is already pending instead of
@@ -180,6 +181,20 @@ export const useCompletion = () => {
   // the pending save reads conversationHistoryRef fresh when it actually runs,
   // so it picks up whatever arrived in the meantime.
   const pendingAutosaveCountRef = useRef(0);
+
+  // Chains a write onto saveQueueRef so it can't run concurrently with any
+  // other queued conversation write. The queue itself never rejects (each
+  // task's outcome is absorbed here) so one failed write can't jam the queue
+  // for whatever runs after it; the caller still sees the task's own
+  // rejection through the returned promise.
+  const queueConversationWrite = useCallback(<T,>(task: () => Promise<T>): Promise<T> => {
+    const result = saveQueueRef.current.then(task, task);
+    saveQueueRef.current = result.then(
+      () => undefined,
+      () => undefined
+    );
+    return result;
+  }, []);
 
   // Generate a readable title for a meeting transcript conversation when it is
   // first auto-saved. Falls back to a timestamped title if no user text exists.
@@ -265,10 +280,8 @@ export const useCompletion = () => {
       }
     };
 
-    const next = saveQueueRef.current.then(run, run);
-    saveQueueRef.current = next;
-    return next;
-  }, []);
+    return queueConversationWrite(run);
+  }, [queueConversationWrite]);
 
   // Keep a ref in sync with the current meeting transcript length so async
   // save paths (normal submit, quick actions) can update the autosave watermark.
@@ -969,7 +982,7 @@ export const useCompletion = () => {
             updatedAt: timestamp,
           };
 
-          await saveConversation(conversation);
+          await queueConversationWrite(() => saveConversation(conversation));
           // Update ref immediately
           conversationHistoryRef.current = newMessages;
           setState((prev) => ({
@@ -1000,6 +1013,7 @@ export const useCompletion = () => {
       allAiProviders,
       systemPrompt,
       submit,
+      queueConversationWrite,
     ]
   );
 
@@ -1219,7 +1233,7 @@ export const useCompletion = () => {
       };
 
       try {
-        await saveConversation(conversation);
+        await queueConversationWrite(() => saveConversation(conversation));
 
         // Update ref immediately
         conversationHistoryRef.current = newMessages;
@@ -1243,7 +1257,7 @@ export const useCompletion = () => {
         }));
       }
     },
-    [state.currentConversationId] // Note: conversationHistory removed - using conversationHistoryRef
+    [state.currentConversationId, queueConversationWrite] // Note: conversationHistory removed - using conversationHistoryRef
   );
 
   // On startup there is no in-progress conversation (state resets to null), so

--- a/src/hooks/useCompletion.ts
+++ b/src/hooks/useCompletion.ts
@@ -6,6 +6,7 @@ import {
   STORAGE_KEYS,
   MEETING_ASSIST_SYSTEM_PROMPT,
   DEFAULT_SYSTEM_PROMPT,
+  MEETING_TRANSCRIPT_AUTOSAVE_INTERVAL,
 } from "@/config";
 import { useApp } from "@/contexts";
 import {
@@ -155,6 +156,88 @@ export const useCompletion = () => {
   const currentRequestIdRef = useRef<string | null>(null);
   const currentConversationIdRef = useRef<string | null>(null);
   const conversationHistoryRef = useRef<ChatMessage[]>([]);
+
+  // Track meeting transcript length and what has been auto-saved so we can
+  // periodically persist transcripts to chat history without stale closures.
+  const meetingTranscriptLengthRef = useRef(0);
+  const lastAutoSavedTranscriptCountRef = useRef(0);
+
+  // Generate a readable title for a meeting transcript conversation when it is
+  // first auto-saved. Falls back to a timestamped title if no user text exists.
+  function generateMeetingTranscriptTitle(firstMessage?: string): string {
+    if (firstMessage?.trim()) {
+      return firstMessage.trim().slice(0, 100);
+    }
+    return `Meeting transcript - ${new Date().toLocaleString()}`;
+  }
+
+  // Persist the current in-memory meeting transcript to chat history. Used by
+  // the periodic autosave and the final flush when the transcript is cleared.
+  const autoSaveMeetingTranscript = useCallback(async (transcriptCount: number) => {
+    const messages = conversationHistoryRef.current;
+    if (messages.length === 0) {
+      return;
+    }
+
+    const conversationId =
+      currentConversationIdRef.current || generateConversationId("chat");
+    currentConversationIdRef.current = conversationId;
+
+    let existingConversation: ChatConversation | null = null;
+    try {
+      existingConversation = await getConversationById(conversationId);
+    } catch (error) {
+      console.error(
+        "[Meeting Transcript Autosave] Failed to load existing conversation:",
+        error
+      );
+    }
+
+    const firstUserMessage = messages.find((msg) => msg.role === "user");
+    const title =
+      existingConversation?.title ||
+      generateMeetingTranscriptTitle(firstUserMessage?.content);
+
+    const conversation: ChatConversation = {
+      id: conversationId,
+      title,
+      messages,
+      createdAt: existingConversation?.createdAt || Date.now(),
+      updatedAt: Date.now(),
+    };
+
+    try {
+      await saveConversation(conversation);
+      setActiveConversationId(conversationId);
+      lastAutoSavedTranscriptCountRef.current = transcriptCount;
+      console.log(
+        `[Meeting Transcript Autosave] Saved ${transcriptCount} transcript segment(s) to conversation ${conversationId}`
+      );
+    } catch (error) {
+      console.error(
+        "[Meeting Transcript Autosave] Failed to save meeting transcript:",
+        error
+      );
+    }
+  }, []);
+
+  // Keep a ref in sync with the current meeting transcript length so async
+  // save paths (normal submit, quick actions) can update the autosave watermark.
+  useEffect(() => {
+    meetingTranscriptLengthRef.current = meetingTranscript.length;
+  }, [meetingTranscript.length]);
+
+  // Periodically auto-save meeting transcripts to chat history while in meeting
+  // assist mode, so nothing is lost if the user never asks the AI a question.
+  useEffect(() => {
+    if (!meetingAssistMode || meetingTranscript.length === 0) return;
+
+    const nextThreshold =
+      lastAutoSavedTranscriptCountRef.current + MEETING_TRANSCRIPT_AUTOSAVE_INTERVAL;
+    if (meetingTranscript.length >= nextThreshold) {
+      autoSaveMeetingTranscript(meetingTranscript.length);
+    }
+  }, [meetingAssistMode, meetingTranscript.length, autoSaveMeetingTranscript]);
 
   const setInput = useCallback((value: string) => {
     setState((prev) => ({ ...prev, input: value }));
@@ -369,19 +452,32 @@ export const useCompletion = () => {
   );
 
   const clearMeetingTranscript = useCallback(() => {
+    // Flush any remaining unsaved transcript segments before clearing so the
+    // user does not lose the final batch if they never hit the autosave threshold.
+    const unsavedCount =
+      meetingTranscript.length - lastAutoSavedTranscriptCountRef.current;
+    if (
+      unsavedCount > 0 &&
+      currentConversationIdRef.current &&
+      conversationHistoryRef.current.length > 0
+    ) {
+      autoSaveMeetingTranscript(meetingTranscript.length);
+    }
+
     setMeetingTranscript([]);
     // Also clear session speaker mapping
     setSessionSpeakerMap({});
     // Also reset conversation when clearing meeting transcript
     currentConversationIdRef.current = null;
     conversationHistoryRef.current = []; // Update ref immediately
+    lastAutoSavedTranscriptCountRef.current = 0;
     setState((prev) => ({
       ...prev,
       currentConversationId: null,
       conversationHistory: [],
       response: "",
     }));
-  }, []);
+  }, [meetingTranscript.length, autoSaveMeetingTranscript]);
 
   /**
    * Assigns a speaker label to a speaker ID and propagates to all matching entries.
@@ -821,6 +917,9 @@ export const useCompletion = () => {
             conversationHistory: newMessages,
             input: "",
           }));
+          // Quick-action saves already persisted any accumulated meeting
+          // transcript, so advance the autosave watermark.
+          lastAutoSavedTranscriptCountRef.current = meetingTranscriptLengthRef.current;
         }
       } catch (error) {
         if (!signal?.aborted && currentRequestIdRef.current === requestId) {
@@ -935,6 +1034,9 @@ export const useCompletion = () => {
     setActiveConversationId(conversation.id);
     currentConversationIdRef.current = conversation.id;
     conversationHistoryRef.current = conversation.messages; // Update ref immediately
+    // Reset autosave watermark relative to any existing meeting transcript so
+    // newly added segments start a fresh count toward the next auto-save.
+    lastAutoSavedTranscriptCountRef.current = meetingTranscript.length;
     setState((prev) => ({
       ...prev,
       currentConversationId: conversation.id,
@@ -944,9 +1046,21 @@ export const useCompletion = () => {
       error: null,
       isLoading: false,
     }));
-  }, [summarizeCurrentConversation]);
+  }, [summarizeCurrentConversation, meetingTranscript.length]);
 
   const startNewConversation = useCallback(() => {
+    // Flush any remaining unsaved meeting transcript before starting a new
+    // conversation so the previous meeting is not lost.
+    const unsavedCount =
+      meetingTranscript.length - lastAutoSavedTranscriptCountRef.current;
+    if (
+      unsavedCount > 0 &&
+      currentConversationIdRef.current &&
+      conversationHistoryRef.current.length > 0
+    ) {
+      autoSaveMeetingTranscript(meetingTranscript.length);
+    }
+
     // Summarize current conversation before starting new
     summarizeCurrentConversation();
 
@@ -954,6 +1068,7 @@ export const useCompletion = () => {
     clearActiveConversationId();
     currentConversationIdRef.current = null;
     conversationHistoryRef.current = []; // Update ref immediately
+    lastAutoSavedTranscriptCountRef.current = 0;
     setState((prev) => ({
       ...prev,
       currentConversationId: null,
@@ -964,7 +1079,7 @@ export const useCompletion = () => {
       isLoading: false,
       attachedFiles: [],
     }));
-  }, [summarizeCurrentConversation]);
+  }, [summarizeCurrentConversation, meetingTranscript.length, autoSaveMeetingTranscript]);
 
   const saveCurrentConversation = useCallback(
     async (
@@ -1039,6 +1154,9 @@ export const useCompletion = () => {
           currentConversationId: conversationId,
           conversationHistory: newMessages,
         }));
+        // Normal AI saves already persisted any accumulated meeting transcript,
+        // so advance the autosave watermark to avoid a redundant flush.
+        lastAutoSavedTranscriptCountRef.current = meetingTranscriptLengthRef.current;
       } catch (error) {
         console.error("Failed to save conversation:", error);
         // Show error to user

--- a/src/hooks/useCompletion.ts
+++ b/src/hooks/useCompletion.ts
@@ -161,6 +161,19 @@ export const useCompletion = () => {
   // periodically persist transcripts to chat history without stale closures.
   const meetingTranscriptLengthRef = useRef(0);
   const lastAutoSavedTranscriptCountRef = useRef(0);
+  // Cached title/createdAt for the conversation currently being auto-saved, so
+  // repeated autosaves don't re-read the row just to recover fields that never
+  // change after the first save. Keyed by id: a mismatched/absent id means a
+  // different (or new) conversation, so the cache is naturally treated as a miss.
+  const conversationMetaCacheRef = useRef<{
+    id: string;
+    title: string;
+    createdAt: number;
+  } | null>(null);
+  // Serializes autosave writes so two threshold crossings that fire close
+  // together can't run concurrent saveConversation calls against the same
+  // conversation id (which does a full delete+reinsert of messages).
+  const saveQueueRef = useRef<Promise<void>>(Promise.resolve());
 
   // Generate a readable title for a meeting transcript conversation when it is
   // first auto-saved. Falls back to a timestamped title if no user text exists.
@@ -173,52 +186,72 @@ export const useCompletion = () => {
 
   // Persist the current in-memory meeting transcript to chat history. Used by
   // the periodic autosave and the final flush when the transcript is cleared.
-  const autoSaveMeetingTranscript = useCallback(async (transcriptCount: number) => {
-    const messages = conversationHistoryRef.current;
-    if (messages.length === 0) {
-      return;
-    }
+  // Queued (not fired directly) so concurrent triggers serialize instead of
+  // racing; callers can still `await` the returned promise for the flush to
+  // actually land before proceeding.
+  const autoSaveMeetingTranscript = useCallback((transcriptCount: number) => {
+    const run = async () => {
+      const messages = conversationHistoryRef.current;
+      if (messages.length === 0) {
+        return;
+      }
 
-    const conversationId =
-      currentConversationIdRef.current || generateConversationId("chat");
-    currentConversationIdRef.current = conversationId;
+      const conversationId =
+        currentConversationIdRef.current || generateConversationId("chat");
+      currentConversationIdRef.current = conversationId;
 
-    let existingConversation: ChatConversation | null = null;
-    try {
-      existingConversation = await getConversationById(conversationId);
-    } catch (error) {
-      console.error(
-        "[Meeting Transcript Autosave] Failed to load existing conversation:",
-        error
-      );
-    }
+      const cachedMeta = conversationMetaCacheRef.current;
+      let title: string;
+      let createdAt: number;
 
-    const firstUserMessage = messages.find((msg) => msg.role === "user");
-    const title =
-      existingConversation?.title ||
-      generateMeetingTranscriptTitle(firstUserMessage?.content);
+      if (cachedMeta && cachedMeta.id === conversationId) {
+        title = cachedMeta.title;
+        createdAt = cachedMeta.createdAt;
+      } else {
+        let existingConversation: ChatConversation | null = null;
+        try {
+          existingConversation = await getConversationById(conversationId);
+        } catch (error) {
+          console.error(
+            "[Meeting Transcript Autosave] Failed to load existing conversation:",
+            error
+          );
+        }
 
-    const conversation: ChatConversation = {
-      id: conversationId,
-      title,
-      messages,
-      createdAt: existingConversation?.createdAt || Date.now(),
-      updatedAt: Date.now(),
+        const firstUserMessage = messages.find((msg) => msg.role === "user");
+        title =
+          existingConversation?.title ||
+          generateMeetingTranscriptTitle(firstUserMessage?.content);
+        createdAt = existingConversation?.createdAt || Date.now();
+      }
+
+      const conversation: ChatConversation = {
+        id: conversationId,
+        title,
+        messages,
+        createdAt,
+        updatedAt: Date.now(),
+      };
+
+      try {
+        await saveConversation(conversation);
+        setActiveConversationId(conversationId);
+        lastAutoSavedTranscriptCountRef.current = transcriptCount;
+        conversationMetaCacheRef.current = { id: conversationId, title, createdAt };
+        console.log(
+          `[Meeting Transcript Autosave] Saved ${transcriptCount} transcript segment(s) to conversation ${conversationId}`
+        );
+      } catch (error) {
+        console.error(
+          "[Meeting Transcript Autosave] Failed to save meeting transcript:",
+          error
+        );
+      }
     };
 
-    try {
-      await saveConversation(conversation);
-      setActiveConversationId(conversationId);
-      lastAutoSavedTranscriptCountRef.current = transcriptCount;
-      console.log(
-        `[Meeting Transcript Autosave] Saved ${transcriptCount} transcript segment(s) to conversation ${conversationId}`
-      );
-    } catch (error) {
-      console.error(
-        "[Meeting Transcript Autosave] Failed to save meeting transcript:",
-        error
-      );
-    }
+    const next = saveQueueRef.current.then(run, run);
+    saveQueueRef.current = next;
+    return next;
   }, []);
 
   // Keep a ref in sync with the current meeting transcript length so async
@@ -451,9 +484,12 @@ export const useCompletion = () => {
     []
   );
 
-  const clearMeetingTranscript = useCallback(() => {
+  const clearMeetingTranscript = useCallback(async () => {
     // Flush any remaining unsaved transcript segments before clearing so the
     // user does not lose the final batch if they never hit the autosave threshold.
+    // Must be awaited: autoSaveMeetingTranscript updates
+    // lastAutoSavedTranscriptCountRef asynchronously, and if it resolves after
+    // the synchronous reset below, it would stomp the reset with the old count.
     const unsavedCount =
       meetingTranscript.length - lastAutoSavedTranscriptCountRef.current;
     if (
@@ -461,7 +497,7 @@ export const useCompletion = () => {
       currentConversationIdRef.current &&
       conversationHistoryRef.current.length > 0
     ) {
-      autoSaveMeetingTranscript(meetingTranscript.length);
+      await autoSaveMeetingTranscript(meetingTranscript.length);
     }
 
     setMeetingTranscript([]);
@@ -1048,9 +1084,10 @@ export const useCompletion = () => {
     }));
   }, [summarizeCurrentConversation, meetingTranscript.length]);
 
-  const startNewConversation = useCallback(() => {
+  const startNewConversation = useCallback(async () => {
     // Flush any remaining unsaved meeting transcript before starting a new
-    // conversation so the previous meeting is not lost.
+    // conversation so the previous meeting is not lost. Must be awaited — see
+    // clearMeetingTranscript for why (async watermark update vs sync reset below).
     const unsavedCount =
       meetingTranscript.length - lastAutoSavedTranscriptCountRef.current;
     if (
@@ -1058,7 +1095,7 @@ export const useCompletion = () => {
       currentConversationIdRef.current &&
       conversationHistoryRef.current.length > 0
     ) {
-      autoSaveMeetingTranscript(meetingTranscript.length);
+      await autoSaveMeetingTranscript(meetingTranscript.length);
     }
 
     // Summarize current conversation before starting new

--- a/src/hooks/useCompletion.ts
+++ b/src/hooks/useCompletion.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback, useRef, useEffect } from "react";
+import { useState, useCallback, useRef, useEffect, Dispatch, SetStateAction } from "react";
 import { useWindowResize } from "./useWindow";
 import { useGlobalShortcuts } from "@/hooks";
 import {
@@ -120,7 +120,7 @@ export const useCompletion = () => {
   const [keepEngaged, setKeepEngaged] = useState(false);
 
   // Meeting Assist Mode state
-  const [meetingAssistMode, setMeetingAssistMode] = useState(() => {
+  const [meetingAssistMode, setMeetingAssistModeState] = useState(() => {
     const stored = localStorage.getItem(STORAGE_KEYS.MEETING_ASSIST_MODE_ENABLED);
     return stored === "true";
   });
@@ -334,6 +334,34 @@ export const useCompletion = () => {
       autoSaveMeetingTranscript();
     }
   }, [meetingAssistMode, meetingTranscript.length, autoSaveMeetingTranscript]);
+
+  // Wraps the raw state setter so turning meeting mode off flushes any
+  // unsaved transcript segments first. The periodic autosave effect above
+  // early-returns once meetingAssistMode is false, so without this a user
+  // with fewer than MEETING_TRANSCRIPT_AUTOSAVE_INTERVAL unsaved segments who
+  // toggles off (without clearing/starting new) then quits loses them.
+  const setMeetingAssistMode = useCallback<Dispatch<SetStateAction<boolean>>>(
+    (value) => {
+      setMeetingAssistModeState((prev) => {
+        const next = typeof value === "function"
+          ? (value as (p: boolean) => boolean)(prev)
+          : value;
+        if (prev && !next) {
+          const unsavedCount =
+            meetingTranscript.length - lastAutoSavedTranscriptCountRef.current;
+          if (
+            unsavedCount > 0 &&
+            currentConversationIdRef.current &&
+            conversationHistoryRef.current.length > 0
+          ) {
+            autoSaveMeetingTranscript();
+          }
+        }
+        return next;
+      });
+    },
+    [meetingTranscript.length, autoSaveMeetingTranscript]
+  );
 
   const setInput = useCallback((value: string) => {
     setState((prev) => ({ ...prev, input: value }));

--- a/src/hooks/useCompletion.ts
+++ b/src/hooks/useCompletion.ts
@@ -124,6 +124,7 @@ export const useCompletion = () => {
     const stored = localStorage.getItem(STORAGE_KEYS.MEETING_ASSIST_MODE_ENABLED);
     return stored === "true";
   });
+  const meetingAssistModeRef = useRef(meetingAssistMode);
   const [meetingTranscript, setMeetingTranscript] = useState<TranscriptEntry[]>([]);
 
   // Session-level speaker mapping (resets when meeting transcript is cleared)
@@ -335,32 +336,43 @@ export const useCompletion = () => {
     }
   }, [meetingAssistMode, meetingTranscript.length, autoSaveMeetingTranscript]);
 
+  // Flush any transcript segments not covered by the latest successful save.
+  // Every meeting-session boundary uses this helper so the persistence guard
+  // and watermark calculation stay consistent.
+  const flushUnsavedMeetingTranscript = useCallback((): Promise<void> => {
+    const unsavedCount =
+      meetingTranscriptLengthRef.current -
+      lastAutoSavedTranscriptCountRef.current;
+    if (
+      unsavedCount <= 0 ||
+      !currentConversationIdRef.current ||
+      conversationHistoryRef.current.length === 0
+    ) {
+      return Promise.resolve();
+    }
+
+    return autoSaveMeetingTranscript();
+  }, [autoSaveMeetingTranscript]);
+
   // Wraps the raw state setter so turning meeting mode off flushes any
-  // unsaved transcript segments first. The periodic autosave effect above
-  // early-returns once meetingAssistMode is false, so without this a user
-  // with fewer than MEETING_TRANSCRIPT_AUTOSAVE_INTERVAL unsaved segments who
-  // toggles off (without clearing/starting new) then quits loses them.
+  // unsaved transcript segments first. Transition state lives in a ref because
+  // invoking persistence from a React state updater is unsafe in StrictMode.
   const setMeetingAssistMode = useCallback<Dispatch<SetStateAction<boolean>>>(
     (value) => {
-      setMeetingAssistModeState((prev) => {
-        const next = typeof value === "function"
-          ? (value as (p: boolean) => boolean)(prev)
+      const previous = meetingAssistModeRef.current;
+      const next =
+        typeof value === "function"
+          ? (value as (p: boolean) => boolean)(previous)
           : value;
-        if (prev && !next) {
-          const unsavedCount =
-            meetingTranscript.length - lastAutoSavedTranscriptCountRef.current;
-          if (
-            unsavedCount > 0 &&
-            currentConversationIdRef.current &&
-            conversationHistoryRef.current.length > 0
-          ) {
-            autoSaveMeetingTranscript();
-          }
-        }
-        return next;
-      });
+
+      meetingAssistModeRef.current = next;
+      setMeetingAssistModeState(next);
+
+      if (previous && !next) {
+        void flushUnsavedMeetingTranscript();
+      }
     },
-    [meetingTranscript.length, autoSaveMeetingTranscript]
+    [flushUnsavedMeetingTranscript]
   );
 
   const setInput = useCallback((value: string) => {
@@ -581,15 +593,7 @@ export const useCompletion = () => {
     // Must be awaited: autoSaveMeetingTranscript updates
     // lastAutoSavedTranscriptCountRef asynchronously, and if it resolves after
     // the synchronous reset below, it would stomp the reset with the old count.
-    const unsavedCount =
-      meetingTranscript.length - lastAutoSavedTranscriptCountRef.current;
-    if (
-      unsavedCount > 0 &&
-      currentConversationIdRef.current &&
-      conversationHistoryRef.current.length > 0
-    ) {
-      await autoSaveMeetingTranscript();
-    }
+    await flushUnsavedMeetingTranscript();
 
     setMeetingTranscript([]);
     // Also clear session speaker mapping
@@ -611,7 +615,7 @@ export const useCompletion = () => {
       conversationHistory: [],
       response: "",
     }));
-  }, [meetingTranscript.length, autoSaveMeetingTranscript]);
+  }, [flushUnsavedMeetingTranscript]);
 
   /**
    * Assigns a speaker label to a speaker ID and propagates to all matching entries.
@@ -1174,15 +1178,7 @@ export const useCompletion = () => {
     // a different one — otherwise those segments are lost, and any further
     // live transcript growth gets appended onto the newly loaded (unrelated)
     // conversation instead.
-    const unsavedCount =
-      meetingTranscript.length - lastAutoSavedTranscriptCountRef.current;
-    if (
-      unsavedCount > 0 &&
-      currentConversationIdRef.current &&
-      conversationHistoryRef.current.length > 0
-    ) {
-      await autoSaveMeetingTranscript();
-    }
+    await flushUnsavedMeetingTranscript();
 
     // Summarize current conversation before switching
     summarizeCurrentConversation();
@@ -1205,21 +1201,17 @@ export const useCompletion = () => {
       error: null,
       isLoading: false,
     }));
-  }, [summarizeCurrentConversation, meetingTranscript.length, autoSaveMeetingTranscript]);
+  }, [
+    summarizeCurrentConversation,
+    meetingTranscript.length,
+    flushUnsavedMeetingTranscript,
+  ]);
 
   const startNewConversation = useCallback(async () => {
     // Flush any remaining unsaved meeting transcript before starting a new
     // conversation so the previous meeting is not lost. Must be awaited — see
     // clearMeetingTranscript for why (async watermark update vs sync reset below).
-    const unsavedCount =
-      meetingTranscript.length - lastAutoSavedTranscriptCountRef.current;
-    if (
-      unsavedCount > 0 &&
-      currentConversationIdRef.current &&
-      conversationHistoryRef.current.length > 0
-    ) {
-      await autoSaveMeetingTranscript();
-    }
+    await flushUnsavedMeetingTranscript();
 
     // Summarize current conversation before starting new
     summarizeCurrentConversation();
@@ -1240,7 +1232,7 @@ export const useCompletion = () => {
       isLoading: false,
       attachedFiles: [],
     }));
-  }, [summarizeCurrentConversation, meetingTranscript.length, autoSaveMeetingTranscript]);
+  }, [summarizeCurrentConversation, flushUnsavedMeetingTranscript]);
 
   const saveCurrentConversation = useCallback(
     async (

--- a/src/lib/database/chat-history.action.ts
+++ b/src/lib/database/chat-history.action.ts
@@ -400,6 +400,64 @@ export async function updateConversation(
 }
 
 /**
+ * Append new messages to an existing conversation without touching rows that
+ * are already persisted. Unlike updateConversation, this does not delete and
+ * re-insert every message, so its cost is proportional to what's new, not to
+ * the conversation's total size — used by the periodic meeting-transcript
+ * autosave, which would otherwise redo a full delete+reinsert of the whole
+ * conversation on every trigger. INSERT OR IGNORE makes retries with an
+ * already-inserted id a no-op instead of a primary-key error, so callers
+ * don't need failure/rollback bookkeeping to stay safe.
+ */
+export async function appendMessagesToConversation(
+  conversationId: string,
+  title: string,
+  updatedAt: number,
+  newMessages: ChatConversation["messages"]
+): Promise<void> {
+  const db = await getDatabase();
+
+  try {
+    await db.execute(
+      "UPDATE conversations SET title = ?, updated_at = ? WHERE id = ?",
+      [title, updatedAt, conversationId]
+    );
+
+    const seenIds = new Set<string>();
+    for (const message of newMessages) {
+      if (!validateMessage(message)) {
+        console.warn("Skipping invalid message in conversation append");
+        continue;
+      }
+      if (seenIds.has(message.id)) {
+        console.warn(`[ChatHistory] Skipping duplicate message ID during append: ${message.id}`);
+        continue;
+      }
+      seenIds.add(message.id);
+
+      const attachedFilesJson = message.attachedFiles
+        ? JSON.stringify(message.attachedFiles)
+        : null;
+
+      await db.execute(
+        "INSERT OR IGNORE INTO messages (id, conversation_id, role, content, timestamp, attached_files) VALUES (?, ?, ?, ?, ?, ?)",
+        [
+          message.id,
+          conversationId,
+          message.role,
+          message.content,
+          message.timestamp,
+          attachedFilesJson,
+        ]
+      );
+    }
+  } catch (error) {
+    console.error("Failed to append messages to conversation:", error);
+    throw error;
+  }
+}
+
+/**
  * Save or update a conversation (upsert operation)
  */
 export async function saveConversation(

--- a/src/lib/database/chat-history.action.ts
+++ b/src/lib/database/chat-history.action.ts
@@ -418,10 +418,14 @@ export async function appendMessagesToConversation(
   const db = await getDatabase();
 
   try {
-    await db.execute(
+    const updateResult = await db.execute(
       "UPDATE conversations SET title = ?, updated_at = ? WHERE id = ?",
       [title, updatedAt, conversationId]
     );
+
+    if (updateResult.rowsAffected === 0) {
+      throw new Error("Conversation not found");
+    }
 
     const seenIds = new Set<string>();
     for (const message of newMessages) {

--- a/src/pages/app/components/completion/Input.tsx
+++ b/src/pages/app/components/completion/Input.tsx
@@ -195,7 +195,7 @@ export const Input = ({
                     reset();
                     // Also clear meeting transcript if in meeting mode
                     if (meetingAssistMode && clearMeetingTranscript) {
-                      clearMeetingTranscript();
+                      await clearMeetingTranscript();
                     }
                   }
                 }}

--- a/src/pages/app/components/completion/Input.tsx
+++ b/src/pages/app/components/completion/Input.tsx
@@ -176,16 +176,20 @@ export const Input = ({
               <Button
                 size="icon"
                 variant="ghost"
-                onClick={() => {
+                onClick={async () => {
                   if (isLoading) {
                     cancel();
                   } else if (keepEngaged) {
-                    // When keepEngaged is on, close everything and start new conversation
+                    // When keepEngaged is on, close everything and start new conversation.
+                    // Awaited in sequence: startNewConversation flushes any unsaved
+                    // transcript and clears currentConversationIdRef itself, so by the
+                    // time clearMeetingTranscript runs there is nothing left for it to
+                    // (redundantly) flush.
                     setKeepEngaged(false);
-                    startNewConversation();
+                    await startNewConversation();
                     // Also clear meeting transcript if in meeting mode
                     if (meetingAssistMode && clearMeetingTranscript) {
-                      clearMeetingTranscript();
+                      await clearMeetingTranscript();
                     }
                   } else {
                     reset();

--- a/src/tests/useCompletion.meeting-assist.test.tsx
+++ b/src/tests/useCompletion.meeting-assist.test.tsx
@@ -1,0 +1,106 @@
+import { PropsWithChildren, StrictMode } from "react";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useCompletion } from "@/hooks/useCompletion";
+import {
+  getConversationById,
+  saveConversation,
+  setActiveConversationId,
+} from "@/lib";
+
+vi.mock("@/contexts", () => ({
+  useApp: () => ({
+    selectedAIProvider: { provider: null },
+    allAiProviders: [],
+    systemPrompt: "",
+    screenshotConfiguration: { enabled: false, mode: "manual" },
+    setScreenshotConfiguration: vi.fn(),
+  }),
+}));
+
+vi.mock("@/hooks", () => ({
+  useGlobalShortcuts: () => ({
+    registerAudioCallback: vi.fn(),
+    registerInputRef: vi.fn(),
+    registerScreenshotCallback: vi.fn(),
+  }),
+}));
+
+vi.mock("@/hooks/useWindow", () => ({
+  useWindowResize: () => ({ resizeWindow: vi.fn() }),
+}));
+
+vi.mock("@/lib", () => ({
+  fetchAIResponse: vi.fn(),
+  saveConversation: vi.fn(),
+  appendMessagesToConversation: vi.fn(),
+  getConversationById: vi.fn(),
+  generateConversationTitle: vi.fn((message: string) => message),
+  shouldUseMeetwingsAPI: vi.fn().mockResolvedValue(false),
+  MESSAGE_ID_OFFSET: 1,
+  generateConversationId: vi.fn(() => "conversation-1"),
+  generateMessageId: vi.fn((role: string, timestamp: number) =>
+    `${role}-${timestamp}`
+  ),
+  generateRequestId: vi.fn(() => "request-1"),
+  getResponseSettings: vi.fn(() => ({ autoScroll: false })),
+  createUsageRecord: vi.fn(),
+  calculateCost: vi.fn(() => 0),
+  calculateSTTCost: vi.fn(() => 0),
+  setActiveConversationId: vi.fn(),
+  clearActiveConversationId: vi.fn(),
+}));
+
+vi.mock("@/lib/functions/meeting-summarizer", () => ({
+  summarizeConversation: vi.fn(),
+  shouldSummarize: vi.fn(() => false),
+}));
+
+vi.mock("@tauri-apps/api/core", () => ({ invoke: vi.fn() }));
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: vi.fn().mockResolvedValue(vi.fn()),
+}));
+
+const strictModeWrapper = ({ children }: PropsWithChildren) => (
+  <StrictMode>{children}</StrictMode>
+);
+
+describe("useCompletion meeting assist mode", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(localStorage.getItem).mockReturnValue(null);
+    vi.mocked(getConversationById).mockResolvedValue(null);
+    vi.mocked(saveConversation).mockResolvedValue({
+      id: "conversation-1",
+      title: "First segment",
+      messages: [],
+      createdAt: 1,
+      updatedAt: 1,
+    });
+  });
+
+  it("queues one transcript flush when StrictMode disables meeting assist", async () => {
+    const { result } = renderHook(() => useCompletion(), {
+      wrapper: strictModeWrapper,
+    });
+
+    act(() => {
+      result.current.setMeetingAssistMode(true);
+    });
+    expect(result.current.meetingAssistMode).toBe(true);
+
+    act(() => {
+      result.current.addMeetingTranscript("First segment");
+    });
+    expect(result.current.meetingTranscript).toHaveLength(1);
+
+    act(() => {
+      result.current.setMeetingAssistMode(false);
+    });
+
+    await waitFor(() => {
+      expect(saveConversation).toHaveBeenCalledTimes(1);
+      expect(setActiveConversationId).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/src/types/completion.hook.ts
+++ b/src/types/completion.hook.ts
@@ -71,10 +71,13 @@ export interface UseCompletionReturn {
   currentConversationId: string | null;
   /** Array of messages in the current conversation */
   conversationHistory: any[];
-  /** Function to load an existing conversation */
-  loadConversation: (conversation: any) => void;
-  /** Function to start a new conversation (clears current state) */
-  startNewConversation: () => void;
+  /** Function to load an existing conversation. Flushes any unsaved meeting
+   * transcript before switching, so callers may await it to ensure that
+   * finishes before further navigation. */
+  loadConversation: (conversation: any) => Promise<void>;
+  /** Function to start a new conversation (clears current state). Flushes any
+   * unsaved meeting transcript first, so callers may await it. */
+  startNewConversation: () => Promise<void>;
 
   // UI state management
   /** Whether the message history modal/panel is open */
@@ -144,8 +147,9 @@ export interface UseCompletionReturn {
   addSystemAudioTranscript: (text: string, timestamp: number) => void;
   /** Function to update translation for a specific transcript entry */
   updateTranscriptTranslation: (timestamp: number, translation?: string, error?: string) => void;
-  /** Function to clear the meeting transcript */
-  clearMeetingTranscript: () => void;
+  /** Function to clear the meeting transcript. Flushes any unsaved segments
+   * first, so callers may await it. */
+  clearMeetingTranscript: () => Promise<void>;
   /** Function to submit a quick action with meeting context */
   submitWithMeetingContext: (action: string) => Promise<void>;
 


### PR DESCRIPTION
## Summary
- Meeting transcripts were only persisted when the user triggered an AI response (Quick Action or submit); a meeting ended without one was lost entirely once cleared or the app restarted.
- Adds a count-based autosave: every 4 transcript segments, the in-progress conversation is upserted to the SQLite chat history so it shows up under Dashboard → Chats.
- `clearMeetingTranscript()` and `startNewConversation()` flush any remaining unsaved segments before resetting state, so at most 3 segments can ever be lost.
- Normal AI-triggered saves (`saveCurrentConversation`, `submitWithMeetingContext`) advance the autosave watermark so the periodic autosave doesn't duplicate work.

## Changes
- `src/config/constants.ts` — new `MEETING_TRANSCRIPT_AUTOSAVE_INTERVAL = 4`
- `src/hooks/useCompletion.ts` — `autoSaveMeetingTranscript()`, watcher effect, watermark tracking, flush-on-clear/new-conversation

## Test plan
- [x] `tsc --noEmit` passes
- [x] `eslint` on changed files: no new errors/warnings
- [ ] Manual: enable Meeting Assist Mode, speak 4+ segments without asking the AI anything, confirm conversation appears in Dashboard → Chats
- [ ] Manual: clear transcript with <4 unsaved segments, confirm final flush saves them
- [ ] Manual: restart app, confirm saved conversation persists

🤖 Generated with [Claude Code](https://claude.com/claude-code)