### PR TITLE
fix: preserve existing conversation title on Quick Actions (#22)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ create-shortcut.ps1
 
 # Documentation - Ignore all documentation files
 docs/*
+.claude/
+.claude-ship-state.json
+.claude-pr-fix-state.json

--- a/src/hooks/useCompletion.ts
+++ b/src/hooks/useCompletion.ts
@@ -1040,13 +1040,27 @@ export const useCompletion = () => {
           // transcript segments stream in while the write is in flight.
           const transcriptLengthAtSnapshot = meetingTranscriptLengthRef.current;
 
+          // Same existing-row read autoSaveMeetingTranscript uses
+          // (useCompletion.ts:253-267): a quick action names a conversation
+          // that has no name, it never renames one. currentHistory is not the
+          // right signal — it tracks in-memory messages, not whether a row
+          // exists.
+          let existingConversation: ChatConversation | null = null;
+          try {
+            existingConversation = await getConversationById(conversationId);
+          } catch (error) {
+            console.error(
+              "[Meeting Assist] Failed to load existing conversation:",
+              error
+            );
+          }
+
           const conversation: ChatConversation = {
             id: conversationId,
-            title: currentHistory.length === 0
-              ? generateConversationTitle(action)
-              : generateConversationTitle(action),
+            title:
+              existingConversation?.title || generateConversationTitle(action),
             messages: newMessages,
-            createdAt: timestamp,
+            createdAt: existingConversation?.createdAt || timestamp,
             updatedAt: timestamp,
           };
 

--- a/src/tests/useCompletion.meeting-assist.test.tsx
+++ b/src/tests/useCompletion.meeting-assist.test.tsx
@@ -3,9 +3,12 @@ import { act, renderHook, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useCompletion } from "@/hooks/useCompletion";
 import {
+  fetchAIResponse,
+  generateConversationTitle,
   getConversationById,
   saveConversation,
   setActiveConversationId,
+  shouldUseMeetwingsAPI,
 } from "@/lib";
 
 vi.mock("@/contexts", () => ({
@@ -65,6 +68,28 @@ const strictModeWrapper = ({ children }: PropsWithChildren) => (
   <StrictMode>{children}</StrictMode>
 );
 
+const EXISTING_CONVERSATION = {
+  id: "conversation-1",
+  title: "Standup with Dana",
+  messages: [],
+  createdAt: 1000,
+  updatedAt: 1000,
+};
+
+// The save block at useCompletion.ts:1022 only runs when the stream produced
+// text, so fetchAIResponse must be an async iterable that yields at least once.
+function mockStreamedResponse(text: string) {
+  vi.mocked(fetchAIResponse).mockImplementation(async function* () {
+    yield text;
+  } as never);
+}
+
+// useApp is mocked with `provider: null`, so the gate at useCompletion.ts:948
+// returns early unless the Meetwings API path is enabled.
+function enableProviderGate() {
+  vi.mocked(shouldUseMeetwingsAPI).mockResolvedValue(true);
+}
+
 describe("useCompletion meeting assist mode", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -77,6 +102,13 @@ describe("useCompletion meeting assist mode", () => {
       createdAt: 1,
       updatedAt: 1,
     });
+    // vi.clearAllMocks() clears call records but PRESERVES implementations,
+    // including any set inside a previous test body. Re-establish both of
+    // these every test so one test's override cannot leak into the next.
+    vi.mocked(shouldUseMeetwingsAPI).mockResolvedValue(false);
+    vi.mocked(fetchAIResponse).mockImplementation(
+      async function* () {} as never
+    );
   });
 
   it("queues one transcript flush when StrictMode disables meeting assist", async () => {
@@ -102,5 +134,125 @@ describe("useCompletion meeting assist mode", () => {
       expect(saveConversation).toHaveBeenCalledTimes(1);
       expect(setActiveConversationId).toHaveBeenCalledTimes(1);
     });
+  });
+
+  it("keeps the existing conversation title when a quick action runs", async () => {
+    enableProviderGate();
+    vi.mocked(getConversationById).mockResolvedValue(EXISTING_CONVERSATION);
+    mockStreamedResponse("Here is your summary.");
+
+    const { result } = renderHook(() => useCompletion(), {
+      wrapper: strictModeWrapper,
+    });
+
+    act(() => {
+      result.current.addMeetingTranscript("Dana: let's review the roadmap");
+    });
+
+    await act(async () => {
+      await result.current.submitWithMeetingContext("Summarize");
+    });
+
+    expect(saveConversation).toHaveBeenCalledTimes(1);
+    expect(saveConversation).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: "conversation-1",
+        title: "Standup with Dana",
+        createdAt: 1000,
+      })
+    );
+    // An existing title must short-circuit the `||`, not merely tie with it.
+    expect(generateConversationTitle).not.toHaveBeenCalled();
+    // Pin WHICH row is read. mockResolvedValue ignores arguments, so without
+    // this an implementation that reads the wrong identifier (e.g.
+    // state.currentConversationId, null on the new-conversation path) still
+    // gets EXISTING_CONVERSATION back and passes.
+    expect(getConversationById).toHaveBeenCalledWith("conversation-1");
+    // updatedAt must still advance. Symmetrically "preserving" it would freeze
+    // the row's updated_at, which is what the chats list sorts on
+    // (chat-history.action.ts:215,241 ORDER BY updated_at DESC), so the
+    // conversation would stop rising to the top after a quick action.
+    expect(
+      vi.mocked(saveConversation).mock.calls[0][0].updatedAt
+    ).toBeGreaterThan(1000);
+  });
+
+  it("names a brand-new conversation after the quick action", async () => {
+    enableProviderGate();
+    vi.mocked(getConversationById).mockResolvedValue(null);
+    mockStreamedResponse("Here is your summary.");
+
+    const { result } = renderHook(() => useCompletion(), {
+      wrapper: strictModeWrapper,
+    });
+
+    act(() => {
+      result.current.addMeetingTranscript("Dana: let's review the roadmap");
+    });
+
+    await act(async () => {
+      await result.current.submitWithMeetingContext("Summarize");
+    });
+
+    expect(saveConversation).toHaveBeenCalledTimes(1);
+    expect(saveConversation).toHaveBeenCalledWith(
+      expect.objectContaining({ title: "Summarize" })
+    );
+  });
+
+  it("names a conversation whose stored title is empty", async () => {
+    enableProviderGate();
+    vi.mocked(getConversationById).mockResolvedValue({
+      ...EXISTING_CONVERSATION,
+      title: "",
+    });
+    mockStreamedResponse("Here is your summary.");
+
+    const { result } = renderHook(() => useCompletion(), {
+      wrapper: strictModeWrapper,
+    });
+
+    act(() => {
+      result.current.addMeetingTranscript("Dana: let's review the roadmap");
+    });
+
+    await act(async () => {
+      await result.current.submitWithMeetingContext("Summarize");
+    });
+
+    // `||` not `??` — a blank stored title must fall through to the action
+    // label, while createdAt is still preserved.
+    expect(saveConversation).toHaveBeenCalledWith(
+      expect.objectContaining({ title: "Summarize", createdAt: 1000 })
+    );
+  });
+
+  it("still saves the conversation when the existing-row read fails", async () => {
+    enableProviderGate();
+    vi.mocked(getConversationById).mockRejectedValue(
+      new Error("db unavailable")
+    );
+    mockStreamedResponse("Here is your summary.");
+
+    const { result } = renderHook(() => useCompletion(), {
+      wrapper: strictModeWrapper,
+    });
+
+    act(() => {
+      result.current.addMeetingTranscript("Dana: let's review the roadmap");
+    });
+
+    await act(async () => {
+      await result.current.submitWithMeetingContext("Summarize");
+    });
+
+    // Without the try/catch the rejection reaches the outer catch at
+    // useCompletion.ts:1069-1076, which skips the save entirely and shows a
+    // completion error even though the AI response succeeded.
+    expect(saveConversation).toHaveBeenCalledTimes(1);
+    expect(saveConversation).toHaveBeenCalledWith(
+      expect.objectContaining({ title: "Summarize" })
+    );
+    expect(result.current.error).toBeNull();
   });
 });

--- a/src/tests/useCompletion.meeting-assist.test.tsx
+++ b/src/tests/useCompletion.meeting-assist.test.tsx
@@ -164,9 +164,8 @@ describe("useCompletion meeting assist mode", () => {
     // An existing title must short-circuit the `||`, not merely tie with it.
     expect(generateConversationTitle).not.toHaveBeenCalled();
     // Pin WHICH row is read. mockResolvedValue ignores arguments, so without
-    // this an implementation that reads the wrong identifier (e.g.
-    // state.currentConversationId, null on the new-conversation path) still
-    // gets EXISTING_CONVERSATION back and passes.
+    // this an implementation that reads an incorrect or undefined identifier
+    // would still receive EXISTING_CONVERSATION and incorrectly pass the test.
     expect(getConversationById).toHaveBeenCalledWith("conversation-1");
     // updatedAt must still advance. Symmetrically "preserving" it would freeze
     // the row's updated_at, which is what the chats list sorts on
@@ -247,7 +246,7 @@ describe("useCompletion meeting assist mode", () => {
     });
 
     // Without the try/catch the rejection reaches the outer catch at
-    // useCompletion.ts:1069-1076, which skips the save entirely and shows a
+    // useCompletion.ts:1083-1091, which skips the save entirely and shows a
     // completion error even though the AI response succeeded.
     expect(saveConversation).toHaveBeenCalledTimes(1);
     expect(saveConversation).toHaveBeenCalledWith(


### PR DESCRIPTION
Fixes #22.

## The bug

In Meeting Assist mode, running a Quick Action ("Summarize", "What should I say?", …) renamed the conversation to the action label, throwing away whatever title it already had. A meeting saved as "Standup with Dana" became "Summarize" the moment the user asked for a summary.

`submitWithMeetingContext` built its `ChatConversation` with a ternary whose two branches were identical:

```ts
title: currentHistory.length === 0
  ? generateConversationTitle(action)
  : generateConversationTitle(action),
```

The conditional was clearly meant to distinguish "first message in a new conversation" from "conversation already exists", but the second branch was never filled in. The same object literal also passed `Date.now()` as `createdAt` on every save — latent today only because `updateConversation` never writes `created_at`.

## The fix

Read the persisted row first and fall back to generating a title only when there isn't one, using the same existing-row read `autoSaveMeetingTranscript` already uses a few hundred lines above.

| Situation | Title after Quick Action | `createdAt` |
|---|---|---|
| Brand-new conversation, no row yet | Action label | Now |
| Row exists with a title | Unchanged | Unchanged |
| Row exists with an empty title | Action label | Unchanged |

Two deliberate choices worth flagging for review:

- **`||`, not `??`** — a row with a blank title *should* get named. Test 3 pins this; swapping the operator fails that test and only that test.
- **The `currentHistory.length === 0` check is dropped, not repaired.** It tracks in-memory messages, not whether a row exists, so it's the wrong signal either way.

## Tests

Four new cases in `src/tests/useCompletion.meeting-assist.test.tsx`, plus the pre-existing one. Two of the four fail against the old code; two are regression guards that passed before and after.

Each of the three semantic decisions was mutation-tested during review — dropping the try/catch, swapping `||` for `??`, and dropping the `createdAt` preservation each break tests, so none of the assertions is decorative.

- `npx vitest run` — 196 passed, 2 skipped, 12 files
- `npm run type-check` — clean
- `npm run lint` — 0 errors

## Scope

This deliberately fixes only the rename. Design review surfaced eight further problems in this code; all are documented rather than fixed here, because an earlier, larger version of this change introduced three new defects of its own. The most serious of them — a pre-existing path where a failed database read can delete an entire conversation and cascade to all its messages — is filed separately as #23.

Known and accepted: the row read sits outside `queueConversationWrite`, so a periodic autosave landing between the read and the write can still overwrite the title. That window can only degrade to the old behavior, never worse, and closing it properly means restructuring the write queue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
