### PR TITLE
fix: stop failed conversation create from deleting the existing row

### DIFF
--- a/src/lib/database/chat-history.action.ts
+++ b/src/lib/database/chat-history.action.ts
@@ -97,6 +97,13 @@ export async function createConversation(
 
   const db = await getDatabase();
 
+  // Whether *this call* inserted the conversation row. The rollback below is a
+  // compensating delete for a partial write, so it must only ever remove a row
+  // this call created. If the INSERT itself failed — most likely because the id
+  // already exists — the row is somebody else's real conversation, and deleting
+  // it cascades to every message it holds.
+  let insertedConversationRow = false;
+
   try {
     // Insert conversation
     await db.execute(
@@ -108,6 +115,7 @@ export async function createConversation(
         conversation.updatedAt || Date.now(),
       ]
     );
+    insertedConversationRow = true;
 
     // Deduplicate messages by ID before inserting. A duplicate ID would violate
     // the messages primary key and abort the whole insert (rolling back the
@@ -150,9 +158,11 @@ export async function createConversation(
   } catch (error) {
     console.error("Failed to create conversation:", error);
     // Rollback: delete conversation if message insertion failed
-    await db
-      .execute("DELETE FROM conversations WHERE id = ?", [conversation.id])
-      .catch(() => {});
+    if (insertedConversationRow) {
+      await db
+        .execute("DELETE FROM conversations WHERE id = ?", [conversation.id])
+        .catch(() => {});
+    }
     throw error;
   }
 }
@@ -297,6 +307,24 @@ export async function getConversationById(
     console.error(`Failed to get conversation ${id}:`, error);
     return null;
   }
+}
+
+/**
+ * Whether a conversation row exists, letting query failures propagate.
+ *
+ * getConversationById returns null on a failed read, which makes a transient
+ * error indistinguishable from "no such row" — fine for read-only callers that
+ * just render "not found", wrong for anything that routes a write on the answer.
+ */
+async function conversationExists(id: string): Promise<boolean> {
+  const db = await getDatabase();
+
+  const rows = await db.select<{ id: string }[]>(
+    "SELECT id FROM conversations WHERE id = ? LIMIT 1",
+    [id]
+  );
+
+  return rows.length > 0;
 }
 
 /**
@@ -472,9 +500,9 @@ export async function saveConversation(
   }
 
   try {
-    const existing = await getConversationById(conversation.id);
-
-    if (existing) {
+    // Deliberately not getConversationById: a read failure there returns null,
+    // which would route an existing conversation into createConversation.
+    if (await conversationExists(conversation.id)) {
       return await updateConversation(conversation);
     } else {
       return await createConversation(conversation);
@@ -586,6 +614,10 @@ export async function migrateLocalStorageToSQLite(): Promise<{
     let errorCount = 0;
 
     for (const conversation of conversations) {
+      // Same rule as createConversation: the cleanup below may only delete a
+      // row this iteration inserted, never a conversation already in the DB.
+      let insertedConversationRow = false;
+
       try {
         // Validate conversation data
         if (!conversation?.id || !conversation?.title) {
@@ -613,6 +645,7 @@ export async function migrateLocalStorageToSQLite(): Promise<{
             conversation.updatedAt || Date.now(),
           ]
         );
+        insertedConversationRow = true;
 
         // Insert messages
         if (
@@ -659,9 +692,13 @@ export async function migrateLocalStorageToSQLite(): Promise<{
         );
         errorCount++;
         // Clean up partially migrated conversation
-        await db
-          .execute("DELETE FROM conversations WHERE id = ?", [conversation?.id])
-          .catch(() => {});
+        if (insertedConversationRow) {
+          await db
+            .execute("DELETE FROM conversations WHERE id = ?", [
+              conversation?.id,
+            ])
+            .catch(() => {});
+        }
       }
     }
 

--- a/src/tests/chat-history.create-rollback.test.ts
+++ b/src/tests/chat-history.create-rollback.test.ts
@@ -1,0 +1,128 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockExecute = vi.fn();
+const mockSelect = vi.fn();
+
+vi.mock("@/lib/database/config", () => ({
+  getDatabase: vi.fn(async () => ({
+    execute: mockExecute,
+    select: mockSelect,
+  })),
+}));
+
+vi.mock("@/lib", () => ({
+  safeLocalStorage: {
+    getItem: vi.fn(() => null),
+    setItem: vi.fn(),
+    removeItem: vi.fn(),
+  },
+}));
+
+import {
+  createConversation,
+  saveConversation,
+} from "@/lib/database/chat-history.action";
+import { ChatConversation } from "@/types";
+
+const CONVERSATION: ChatConversation = {
+  id: "conversation-1",
+  title: "Existing title",
+  createdAt: 1000,
+  updatedAt: 2000,
+  messages: [
+    { id: "msg-1", role: "user", content: "hello", timestamp: 1000 },
+    { id: "msg-2", role: "assistant", content: "hi", timestamp: 1001 },
+  ],
+};
+
+/** SQL statements passed to db.execute, whitespace-normalized. */
+function executedSql(): string[] {
+  return mockExecute.mock.calls.map((call) =>
+    String(call[0]).replace(/\s+/g, " ").trim()
+  );
+}
+
+function deleteConversationCalls(): unknown[][] {
+  return mockExecute.mock.calls.filter((call) =>
+    /^DELETE FROM conversations/i.test(String(call[0]).trim())
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockExecute.mockResolvedValue({ rowsAffected: 1, lastInsertId: 0 });
+  mockSelect.mockResolvedValue([]);
+});
+
+describe("createConversation rollback", () => {
+  it("does not delete the conversation when the conversation INSERT itself fails", async () => {
+    // A pre-existing row with the same id: the INSERT hits the primary key.
+    mockExecute.mockImplementation(async (sql: string) => {
+      if (/INSERT INTO conversations/i.test(sql)) {
+        throw new Error("UNIQUE constraint failed: conversations.id");
+      }
+      return { rowsAffected: 1, lastInsertId: 0 };
+    });
+
+    await expect(createConversation(CONVERSATION)).rejects.toThrow(
+      /UNIQUE constraint failed/
+    );
+
+    // The row belongs to a real conversation this call never created, and
+    // messages cascade on delete.
+    expect(deleteConversationCalls()).toHaveLength(0);
+  });
+
+  it("still deletes the conversation it inserted when a message INSERT fails", async () => {
+    mockExecute.mockImplementation(async (sql: string) => {
+      if (/INSERT INTO messages/i.test(sql)) {
+        throw new Error("disk I/O error");
+      }
+      return { rowsAffected: 1, lastInsertId: 0 };
+    });
+
+    await expect(createConversation(CONVERSATION)).rejects.toThrow(
+      /disk I\/O error/
+    );
+
+    const deletes = deleteConversationCalls();
+    expect(deletes).toHaveLength(1);
+    expect(deletes[0][1]).toEqual(["conversation-1"]);
+  });
+});
+
+describe("saveConversation routing", () => {
+  it("propagates a failed existence read instead of treating it as absent", async () => {
+    mockSelect.mockRejectedValue(new Error("database is locked"));
+
+    await expect(saveConversation(CONVERSATION)).rejects.toThrow(
+      /database is locked/
+    );
+
+    // No create attempt, so no rollback delete can fire.
+    expect(executedSql()).toHaveLength(0);
+  });
+
+  it("updates when the conversation already exists", async () => {
+    mockSelect.mockResolvedValue([{ id: "conversation-1" }]);
+
+    await saveConversation(CONVERSATION);
+
+    expect(executedSql()).toContainEqual(
+      expect.stringMatching(/^UPDATE conversations/i)
+    );
+    expect(executedSql()).not.toContainEqual(
+      expect.stringMatching(/^INSERT INTO conversations/i)
+    );
+  });
+
+  it("creates when the conversation does not exist", async () => {
+    mockSelect.mockResolvedValue([]);
+
+    await saveConversation(CONVERSATION);
+
+    expect(executedSql()).toContainEqual(
+      expect.stringMatching(/^INSERT INTO conversations/i)
+    );
+  });
+});


### PR DESCRIPTION
Closes #23

## The bug

`createConversation`'s catch block deleted the conversation row unconditionally, treating every failure as a partial write to compensate for. When the failing statement was the conversation `INSERT` itself — a primary-key conflict with a row that already existed — the delete removed a real conversation, and `messages`' `ON DELETE CASCADE` took its whole transcript with it.

The route into that state is `saveConversation`: `getConversationById` returns `null` on a failed read, so a transient error is indistinguishable from "no such row", and an existing conversation gets sent down the create path.

## Changes

**`createConversation`** — track whether this call actually inserted the conversation row; only run the rollback DELETE when it did. A failed INSERT now just rethrows, leaving the pre-existing row and its messages intact.

**`migrateLocalStorageToSQLite`** — same unguarded cleanup delete existed per-conversation in the migration loop, reachable the same way (its `getConversationById` pre-check also returns `null` on a failed read). Guarded identically.

**`saveConversation`** — routes on a new module-private `conversationExists`, which lets query failures propagate instead of reading them as absence. `getConversationById` keeps its null-on-error contract for read-only callers that just render "not found" (`View.tsx`, the conversation-selected handlers).

Not done here: `useCompletion.ts` still reads `existingConversation` via `getConversationById` and falls back to `null` on error. That path is not destructive — worst case it re-derives a title — so it is left for a separate change rather than widening this one.

## Tests

New `src/tests/chat-history.create-rollback.test.ts` (5 cases), against a mocked `getDatabase`:

- conversation INSERT fails → no `DELETE FROM conversations` is issued, error rethrown
- message INSERT fails → the row this call inserted *is* deleted (existing rollback still works)
- `saveConversation` with a failing existence read → rejects, and no statement is executed at all
- `saveConversation` routes to UPDATE when the row exists, INSERT when it doesn't

Both rollback tests fail on `main` before the fix. Full suite: 201 passed, 2 skipped. `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)