### PR TITLE
feat: name conversations with an AI-generated title

### DIFF
--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -31,6 +31,9 @@ export const STORAGE_KEYS = {
   // Meeting Assist Mode settings
   MEETING_ASSIST_MODE_ENABLED: "meeting_assist_mode_enabled",
 
+  // AI-generated conversation titles
+  AI_TITLES_ENABLED: "ai_titles_enabled",
+
   // STT Language setting
   STT_LANGUAGE: "stt_language",
 

--- a/src/hooks/useCompletion.ts
+++ b/src/hooks/useCompletion.ts
@@ -31,6 +31,10 @@ import {
   summarizeConversation,
   shouldSummarize,
 } from "@/lib/functions/meeting-summarizer";
+import {
+  applyAIConversationTitle,
+  type TitleProviderConfig,
+} from "@/lib/functions/conversation-title";
 import type { UsageData, TranscriptEntry, SpeakerInfo } from "@/types";
 import { SpeakerIdFactory } from "@/types";
 import { invoke } from "@tauri-apps/api/core";
@@ -191,6 +195,55 @@ export const useCompletion = () => {
   // so it picks up whatever arrived in the meantime.
   const pendingAutosaveCountRef = useRef(0);
 
+  // Provider wiring for the background title call, held in a ref so the save
+  // callbacks below don't take the provider list as a dependency and get a new
+  // identity every time it changes.
+  const titleProviderConfigRef = useRef<TitleProviderConfig>({
+    provider: undefined,
+    selectedProvider: { provider: "", variables: {} },
+  });
+  useEffect(() => {
+    titleProviderConfigRef.current = {
+      provider: allAiProviders.find((p) => p.id === selectedAIProvider.provider),
+      selectedProvider: selectedAIProvider,
+    };
+  }, [allAiProviders, selectedAIProvider]);
+
+  // Replaces a just-created conversation's fallback title (the raw first
+  // message) with an AI-generated one. Fire-and-forget on purpose: it must not
+  // delay the save path, and applyAIConversationTitle swallows its own
+  // failures, leaving the fallback title in place.
+  const requestAITitle = useCallback(
+    (conversationId: string, messages: ChatMessage[]) => {
+      void applyAIConversationTitle(
+        conversationId,
+        messages.map((msg) => ({ role: msg.role, content: msg.content })),
+        titleProviderConfigRef.current
+      );
+    },
+    []
+  );
+
+  // The generated title lands in the database directly, so the cached copy the
+  // transcript autosave reuses has to be corrected — otherwise the next append
+  // writes the stale fallback title back over it.
+  useEffect(() => {
+    const handleTitleUpdated = (event: Event) => {
+      const { id, title } = (event as CustomEvent).detail || {};
+      const cached = conversationMetaCacheRef.current;
+      if (cached && cached.id === id && typeof title === "string") {
+        conversationMetaCacheRef.current = { ...cached, title };
+      }
+    };
+
+    window.addEventListener("conversation-title-updated", handleTitleUpdated);
+    return () =>
+      window.removeEventListener(
+        "conversation-title-updated",
+        handleTitleUpdated
+      );
+  }, []);
+
   // Chains a write onto saveQueueRef so it can't run concurrently with any
   // other queued conversation write. The queue itself never rejects (each
   // task's outcome is absorbed here) so one failed write can't jam the queue
@@ -245,10 +298,15 @@ export const useCompletion = () => {
         const cachedMeta = conversationMetaCacheRef.current;
         let title: string;
         let createdAt: number;
+        // Whether `title` is a name this conversation already had, as opposed
+        // to one this run just invented. Only the invented case may be handed
+        // to the AI titler — the rest are somebody's real title.
+        let hasStoredTitle: boolean;
 
         if (cachedMeta && cachedMeta.id === conversationId) {
           title = cachedMeta.title;
           createdAt = cachedMeta.createdAt;
+          hasStoredTitle = true;
         } else {
           let existingConversation: ChatConversation | null = null;
           try {
@@ -265,6 +323,7 @@ export const useCompletion = () => {
             existingConversation?.title ||
             generateMeetingTranscriptTitle(firstUserMessage?.content);
           createdAt = existingConversation?.createdAt || Date.now();
+          hasStoredTitle = Boolean(existingConversation?.title);
         }
 
         try {
@@ -297,7 +356,19 @@ export const useCompletion = () => {
           const savedCount = transcriptLengthAtSnapshot;
           lastAutoSavedTranscriptCountRef.current = savedCount;
           persistedMessageCountRef.current = messages.length;
-          conversationMetaCacheRef.current = { id: conversationId, title, createdAt };
+          const latestMeta = conversationMetaCacheRef.current;
+          conversationMetaCacheRef.current = {
+            id: conversationId,
+            // A generated title may have landed while this save was in flight.
+            // Restoring the title this run started with would put the fallback
+            // back in the cache, and the next append would write it to the row.
+            title:
+              latestMeta?.id === conversationId ? latestMeta.title : title,
+            createdAt,
+          };
+          if (!hasStoredTitle) {
+            requestAITitle(conversationId, messages);
+          }
           console.log(
             `[Meeting Transcript Autosave] Saved ${savedCount} transcript segment(s) to conversation ${conversationId}`
           );
@@ -313,7 +384,7 @@ export const useCompletion = () => {
     };
 
     return queueConversationWrite(run);
-  }, [queueConversationWrite]);
+  }, [queueConversationWrite, requestAITitle]);
 
   // Keep a ref in sync with the current meeting transcript length so async
   // save paths (normal submit, quick actions) can update the autosave watermark.
@@ -1079,6 +1150,11 @@ export const useCompletion = () => {
           // This was a full rewrite of every message, so all of them are now
           // persisted — the next periodic autosave can append from here.
           persistedMessageCountRef.current = newMessages.length;
+          // Same rule as the title above: name a conversation that has none,
+          // never rename one.
+          if (!existingConversation?.title) {
+            requestAITitle(conversationId, newMessages);
+          }
         }
       } catch (error) {
         if (!signal?.aborted && currentRequestIdRef.current === requestId) {
@@ -1099,6 +1175,7 @@ export const useCompletion = () => {
       systemPrompt,
       submit,
       queueConversationWrite,
+      requestAITitle,
     ]
   );
 
@@ -1331,6 +1408,11 @@ export const useCompletion = () => {
         // This was a full rewrite of every message, so all of them are now
         // persisted — the next periodic autosave can append from here.
         persistedMessageCountRef.current = newMessages.length;
+        // The conversation had no name before this save, so the title stored
+        // above is the raw first message — hand it to the AI titler.
+        if (!existingConversation?.title) {
+          requestAITitle(conversationId, newMessages);
+        }
       } catch (error) {
         console.error("Failed to save conversation:", error);
         // Show error to user
@@ -1340,7 +1422,7 @@ export const useCompletion = () => {
         }));
       }
     },
-    [state.currentConversationId, queueConversationWrite] // Note: conversationHistory removed - using conversationHistoryRef
+    [state.currentConversationId, queueConversationWrite, requestAITitle] // Note: conversationHistory removed - using conversationHistoryRef
   );
 
   // On startup there is no in-progress conversation (state resets to null), so

--- a/src/hooks/useHistory.ts
+++ b/src/hooks/useHistory.ts
@@ -76,6 +76,32 @@ export function useHistory(): UseHistoryReturn {
     refreshConversations();
   }, [refreshConversations]);
 
+  // AI titles are generated in the background and written straight to the
+  // database, so a list rendered before one lands would keep showing the
+  // fallback title until the next full refresh.
+  useEffect(() => {
+    const handleTitleUpdated = (event: Event) => {
+      const { id, title } = (event as CustomEvent).detail || {};
+      if (!id || typeof title !== "string") return;
+
+      setConversations((prev) =>
+        prev.map((conversation) =>
+          conversation.id === id ? { ...conversation, title } : conversation
+        )
+      );
+      setViewingConversation((prev) =>
+        prev && prev.id === id ? { ...prev, title } : prev
+      );
+    };
+
+    window.addEventListener("conversation-title-updated", handleTitleUpdated);
+    return () =>
+      window.removeEventListener(
+        "conversation-title-updated",
+        handleTitleUpdated
+      );
+  }, []);
+
   const handleViewConversation = (conversation: ChatConversation) => {
     setViewingConversation(conversation);
   };

--- a/src/hooks/useSystemAudio.ts
+++ b/src/hooks/useSystemAudio.ts
@@ -131,6 +131,14 @@ export function useSystemAudio() {
     };
   }, [allAiProviders, selectedAIProvider]);
 
+  // Conversation ids this hook minted itself, and so knows have no stored title
+  // yet. Only those may be renamed by the titler. setConversation is part of the
+  // hook's public surface, so a future caller could load an existing — possibly
+  // user-named — conversation in here, and renaming that would destroy a real
+  // title. Checking conversation.title instead would not work: the in-memory
+  // title is always the fallback by the time the save runs.
+  const selfCreatedConversationIdsRef = useRef<Set<string>>(new Set());
+
   // The titler writes straight to the database, so mirror the new title into
   // local state — otherwise the next debounced save writes the stale fallback
   // title back over it.
@@ -580,6 +588,7 @@ export function useSystemAudio() {
 
       // Set up conversation
       const conversationId = generateConversationId("sysaudio");
+      selfCreatedConversationIdsRef.current.add(conversationId);
       setConversation({
         id: conversationId,
         title: "",
@@ -833,14 +842,16 @@ export function useSystemAudio() {
         // Replace the fallback title (the raw first transcription) with an
         // AI-generated one. One-shot per conversation — applyAIConversationTitle
         // ignores repeat calls, so the debounced saves that follow are no-ops.
-        void applyAIConversationTitle(
-          conversation.id,
-          conversation.messages.map((msg) => ({
-            role: msg.role,
-            content: msg.content,
-          })),
-          titleProviderConfigRef.current
-        );
+        if (selfCreatedConversationIdsRef.current.has(conversation.id)) {
+          void applyAIConversationTitle(
+            conversation.id,
+            conversation.messages.map((msg) => ({
+              role: msg.role,
+              content: msg.content,
+            })),
+            titleProviderConfigRef.current
+          );
+        }
       } catch (error) {
         console.error("Failed to save system audio conversation:", error);
       } finally {
@@ -862,8 +873,10 @@ export function useSystemAudio() {
   ]);
 
   const startNewConversation = useCallback(() => {
+    const conversationId = generateConversationId("sysaudio");
+    selfCreatedConversationIdsRef.current.add(conversationId);
     setConversation({
-      id: generateConversationId("sysaudio"),
+      id: conversationId,
       title: "",
       messages: [],
       createdAt: 0,

--- a/src/hooks/useSystemAudio.ts
+++ b/src/hooks/useSystemAudio.ts
@@ -5,6 +5,10 @@ import { listen } from "@tauri-apps/api/event";
 import { useApp } from "@/contexts";
 import { fetchSTT, fetchAIResponse, summarizeConversation, shouldSummarize } from "@/lib/functions";
 import {
+  applyAIConversationTitle,
+  type TitleProviderConfig,
+} from "@/lib/functions/conversation-title";
+import {
   DEFAULT_QUICK_ACTIONS,
   DEFAULT_SYSTEM_PROMPT,
   STORAGE_KEYS,
@@ -112,6 +116,38 @@ export function useSystemAudio() {
   const abortControllerRef = useRef<AbortController | null>(null);
   const saveTimeoutRef = useRef<NodeJS.Timeout | null>(null);
   const isSavingRef = useRef<boolean>(false);
+
+  // Provider wiring for the background title call, held in a ref so the
+  // debounced save effect below doesn't restart every time the provider list
+  // or selection changes.
+  const titleProviderConfigRef = useRef<TitleProviderConfig>({
+    provider: undefined,
+    selectedProvider: { provider: "", variables: {} },
+  });
+  useEffect(() => {
+    titleProviderConfigRef.current = {
+      provider: allAiProviders.find((p) => p.id === selectedAIProvider.provider),
+      selectedProvider: selectedAIProvider,
+    };
+  }, [allAiProviders, selectedAIProvider]);
+
+  // The titler writes straight to the database, so mirror the new title into
+  // local state — otherwise the next debounced save writes the stale fallback
+  // title back over it.
+  useEffect(() => {
+    const handleTitleUpdated = (event: Event) => {
+      const { id, title } = (event as CustomEvent).detail || {};
+      if (!id || typeof title !== "string") return;
+      setConversation((prev) => (prev.id === id ? { ...prev, title } : prev));
+    };
+
+    window.addEventListener("conversation-title-updated", handleTitleUpdated);
+    return () =>
+      window.removeEventListener(
+        "conversation-title-updated",
+        handleTitleUpdated
+      );
+  }, []);
   const scrollAreaRef = useRef<HTMLDivElement>(null);
 
   // Load context settings and VAD config from localStorage on mount
@@ -794,6 +830,17 @@ export function useSystemAudio() {
       try {
         isSavingRef.current = true;
         await saveConversation(conversation);
+        // Replace the fallback title (the raw first transcription) with an
+        // AI-generated one. One-shot per conversation — applyAIConversationTitle
+        // ignores repeat calls, so the debounced saves that follow are no-ops.
+        void applyAIConversationTitle(
+          conversation.id,
+          conversation.messages.map((msg) => ({
+            role: msg.role,
+            content: msg.content,
+          })),
+          titleProviderConfigRef.current
+        );
       } catch (error) {
         console.error("Failed to save system audio conversation:", error);
       } finally {

--- a/src/lib/database/chat-history.action.ts
+++ b/src/lib/database/chat-history.action.ts
@@ -514,12 +514,17 @@ export async function updateConversationTitle(
 
   const db = await getDatabase();
 
-  const result = await db.execute(
-    "UPDATE conversations SET title = ? WHERE id = ?",
-    [title, id]
-  );
+  try {
+    const result = await db.execute(
+      "UPDATE conversations SET title = ? WHERE id = ?",
+      [title, id]
+    );
 
-  return result.rowsAffected > 0;
+    return result.rowsAffected > 0;
+  } catch (error) {
+    console.error(`Failed to rename conversation ${id}:`, error);
+    throw error;
+  }
 }
 
 /**

--- a/src/lib/database/chat-history.action.ts
+++ b/src/lib/database/chat-history.action.ts
@@ -490,6 +490,39 @@ export async function appendMessagesToConversation(
 }
 
 /**
+ * Rename a conversation without touching its messages or its position in the
+ * chats list. Deliberately leaves updated_at alone: a rename is not new
+ * activity, and the list sorts and groups conversations by that column, so
+ * bumping it would jump the conversation to "now" just because a background
+ * title generation landed.
+ *
+ * Returns false when no row matched — e.g. the conversation was deleted while
+ * the title was being generated.
+ */
+export async function updateConversationTitle(
+  id: string,
+  title: string
+): Promise<boolean> {
+  if (!id || typeof id !== "string") {
+    console.error("Invalid conversation id");
+    return false;
+  }
+  if (!title || typeof title !== "string") {
+    console.error("Invalid conversation title");
+    return false;
+  }
+
+  const db = await getDatabase();
+
+  const result = await db.execute(
+    "UPDATE conversations SET title = ? WHERE id = ?",
+    [title, id]
+  );
+
+  return result.rowsAffected > 0;
+}
+
+/**
  * Save or update a conversation (upsert operation)
  */
 export async function saveConversation(

--- a/src/lib/functions/conversation-title.ts
+++ b/src/lib/functions/conversation-title.ts
@@ -159,6 +159,7 @@ export async function generateAIConversationTitle(
     }
 
     let raw = "";
+    const controller = new AbortController();
     for await (const chunk of fetchAIResponse({
       provider: useMeetwingsAPI ? undefined : providerConfig?.provider,
       selectedProvider: providerConfig?.selectedProvider || {
@@ -169,11 +170,19 @@ export async function generateAIConversationTitle(
       history: [],
       userMessage: `CONVERSATION:\n${excerpt}\n\nProvide the JSON title:`,
       imagesBase64: [],
+      signal: controller.signal,
     })) {
       raw += chunk;
       // Stop reading a response that has already blown past any plausible
       // title rather than buffering a whole runaway generation.
+      //
+      // Abort before breaking: leaving the loop tears the generator down with
+      // .return(), which runs finally blocks only, and fetchAIResponse's
+      // streaming branch has none — its reader.cancel() sits behind abort
+      // checks that never get to run. Aborting cancels the fetch itself, which
+      // is what actually releases the HTTP stream.
       if (raw.length > MAX_RAW_RESPONSE_LENGTH) {
+        controller.abort();
         break;
       }
     }

--- a/src/lib/functions/conversation-title.ts
+++ b/src/lib/functions/conversation-title.ts
@@ -1,0 +1,243 @@
+import { Message, TYPE_PROVIDER } from "@/types";
+import { STORAGE_KEYS } from "@/config";
+import { safeLocalStorage } from "@/lib/storage";
+import { updateConversationTitle } from "@/lib/database";
+import { fetchAIResponse } from "./ai-response.function";
+import { extractJsonObject } from "./meeting-summarizer";
+import { shouldUseMeetwingsAPI } from "./meetwings.api";
+
+/** Longest title we will store. Beyond this the chats list just clips it. */
+export const MAX_AI_TITLE_LENGTH = 60;
+
+/**
+ * Upper bound on the raw model output we will even look at. A well-behaved
+ * response is a few dozen characters of JSON; anything far past that is the
+ * model ignoring the format, and parsing it out is not worth the risk of
+ * storing a paragraph as a title.
+ */
+const MAX_RAW_RESPONSE_LENGTH = 500;
+
+/** How many messages from the start of the conversation to send. */
+const MESSAGES_FOR_TITLE = 4;
+
+/** How much of each message to send. Titles don't need the whole transcript. */
+const MAX_MESSAGE_CHARS = 1000;
+
+export interface TitleProviderConfig {
+  provider: TYPE_PROVIDER | undefined;
+  selectedProvider: {
+    provider: string;
+    variables: Record<string, string>;
+  };
+}
+
+/**
+ * JSON is requested rather than a bare line of text because fetchAIResponse
+ * reports failures by *yielding* an error string ("Meetwings API Error: ...")
+ * instead of throwing. A bare-text contract would happily store that error as
+ * the conversation's title; requiring a JSON envelope makes every such
+ * response fail to parse and fall through to the caller's existing fallback.
+ */
+const TITLE_PROMPT = `You name conversations. Read the excerpt and produce a short title describing what it is about.
+
+Respond ONLY with a valid JSON object, no markdown and no code fences:
+{"title": "Short descriptive title"}
+
+Rules:
+- 3 to 6 words, under ${MAX_AI_TITLE_LENGTH} characters
+- Describe the subject matter, not the format ("Q3 Budget Review", not "A conversation about a budget")
+- Title Case, no trailing punctuation, no surrounding quotes
+- Use the conversation's own language
+- If the excerpt is too short or empty to tell, use a plain topical guess rather than refusing`;
+
+/**
+ * Whether AI title generation is turned on. Defaults to enabled; the toggle
+ * exists because each new conversation costs one extra (small) API call.
+ */
+export function isAITitleEnabled(): boolean {
+  return safeLocalStorage.getItem(STORAGE_KEYS.AI_TITLES_ENABLED) !== "false";
+}
+
+/**
+ * Turns a raw model response into a storable title, or null if it isn't one.
+ */
+export function parseGeneratedTitle(raw: string): string | null {
+  if (!raw || raw.length > MAX_RAW_RESPONSE_LENGTH) {
+    return null;
+  }
+
+  let title: unknown;
+  try {
+    title = JSON.parse(extractJsonObject(raw))?.title;
+  } catch {
+    return null;
+  }
+
+  if (typeof title !== "string") {
+    return null;
+  }
+
+  const cleaned = title
+    .replace(/\s+/g, " ")
+    // Models like to wrap titles in quotes despite being told not to.
+    .replace(/^["'“”‘’`]+|["'“”‘’`]+$/g, "")
+    // ...and to prefix them with markdown heading or list syntax.
+    .replace(/^[#*\-\s]+/, "")
+    .replace(/[.,;:]+$/, "")
+    .trim();
+
+  if (!cleaned) {
+    return null;
+  }
+
+  if (cleaned.length <= MAX_AI_TITLE_LENGTH) {
+    return cleaned;
+  }
+
+  // Cut at the last word boundary that fits, so an over-long title ends on a
+  // whole word instead of mid-syllable. Falls back to a hard cut when the
+  // first word alone is longer than the budget.
+  const clipped = cleaned.slice(0, MAX_AI_TITLE_LENGTH);
+  const lastSpace = clipped.lastIndexOf(" ");
+  return (lastSpace > 0 ? clipped.slice(0, lastSpace) : clipped).trim();
+}
+
+/**
+ * Flattens a message's content to plain text. Message content is either a
+ * string or an array of multimodal parts; only the text parts can contribute
+ * to a title, and image parts are dropped rather than stringified.
+ */
+function messageText(content: Message["content"]): string {
+  if (typeof content === "string") {
+    return content;
+  }
+  if (!Array.isArray(content)) {
+    return "";
+  }
+  return content
+    .map((part) => (typeof part?.text === "string" ? part.text : ""))
+    .filter(Boolean)
+    .join(" ");
+}
+
+/**
+ * Builds the excerpt sent to the model: the opening messages of the
+ * conversation, each truncated, which is enough to name it and keeps the call
+ * cheap on a long meeting transcript.
+ */
+function formatExcerpt(messages: Message[]): string {
+  return messages
+    .slice(0, MESSAGES_FOR_TITLE)
+    .map((msg) => {
+      const role = msg.role === "user" ? "User" : "Assistant";
+      const content = messageText(msg.content).slice(0, MAX_MESSAGE_CHARS);
+      return `${role}: ${content}`;
+    })
+    .filter((line) => line.replace(/^(User|Assistant): /, "").trim())
+    .join("\n\n");
+}
+
+/**
+ * Asks the AI for a title for a conversation. Returns null whenever a title
+ * can't be produced — no provider, request failed, unparseable response — so
+ * callers keep whatever fallback title they already computed.
+ */
+export async function generateAIConversationTitle(
+  messages: Message[],
+  providerConfig?: TitleProviderConfig
+): Promise<string | null> {
+  const excerpt = formatExcerpt(messages).trim();
+  if (!excerpt) {
+    return null;
+  }
+
+  try {
+    const useMeetwingsAPI = await shouldUseMeetwingsAPI();
+
+    if (!useMeetwingsAPI && !providerConfig?.provider) {
+      return null;
+    }
+
+    let raw = "";
+    for await (const chunk of fetchAIResponse({
+      provider: useMeetwingsAPI ? undefined : providerConfig?.provider,
+      selectedProvider: providerConfig?.selectedProvider || {
+        provider: "",
+        variables: {},
+      },
+      systemPrompt: TITLE_PROMPT,
+      history: [],
+      userMessage: `CONVERSATION:\n${excerpt}\n\nProvide the JSON title:`,
+      imagesBase64: [],
+    })) {
+      raw += chunk;
+      // Stop reading a response that has already blown past any plausible
+      // title rather than buffering a whole runaway generation.
+      if (raw.length > MAX_RAW_RESPONSE_LENGTH) {
+        break;
+      }
+    }
+
+    return parseGeneratedTitle(raw);
+  } catch (error) {
+    console.error("[AI Title] Failed to generate conversation title:", error);
+    return null;
+  }
+}
+
+/**
+ * Conversations this session has already tried to title. Titling is a
+ * one-shot per conversation: it runs right after the row is created, and every
+ * later save preserves the stored title, so a second attempt would either be a
+ * no-op or would rename a conversation out from under the user.
+ */
+const attempted = new Set<string>();
+
+/**
+ * Generates a title for a freshly created conversation and writes it to the
+ * database, replacing the caller's fallback title. Fire-and-forget: it never
+ * throws and never blocks the save path.
+ *
+ * Resolves to the stored title, or null if nothing was stored (disabled,
+ * already attempted, generation failed, or the row is gone).
+ */
+export async function applyAIConversationTitle(
+  conversationId: string,
+  messages: Message[],
+  providerConfig?: TitleProviderConfig
+): Promise<string | null> {
+  if (!conversationId || attempted.has(conversationId) || !isAITitleEnabled()) {
+    return null;
+  }
+  // Claimed before the first await so concurrent callers — the save path and
+  // the transcript autosave can both fire for the same new conversation —
+  // can't each spend an API call on it.
+  attempted.add(conversationId);
+
+  try {
+    const title = await generateAIConversationTitle(messages, providerConfig);
+    if (!title) {
+      return null;
+    }
+
+    const renamed = await updateConversationTitle(conversationId, title);
+    if (!renamed) {
+      return null;
+    }
+
+    // Lets in-memory holders of the old title (the chats list, the completion
+    // hook's conversation metadata cache) catch up without re-reading the row.
+    if (typeof window !== "undefined") {
+      window.dispatchEvent(
+        new CustomEvent("conversation-title-updated", {
+          detail: { id: conversationId, title },
+        })
+      );
+    }
+
+    return title;
+  } catch (error) {
+    console.error("[AI Title] Failed to apply conversation title:", error);
+    return null;
+  }
+}

--- a/src/lib/functions/index.ts
+++ b/src/lib/functions/index.ts
@@ -4,6 +4,7 @@ export * from "./assemblyai.function";
 export * from "./common.function";
 export * from "./meetwings.api";
 export * from "./meeting-summarizer";
+export * from "./conversation-title";
 export * from "./knowledge-compactor";
 export * from "./context-builder";
 export * from "./translation.function";

--- a/src/pages/settings/components/AITitlesToggle.tsx
+++ b/src/pages/settings/components/AITitlesToggle.tsx
@@ -1,0 +1,52 @@
+import { useEffect, useState } from "react";
+import { Switch, Label, Header } from "@/components";
+import { STORAGE_KEYS } from "@/config";
+import { safeLocalStorage } from "@/lib";
+import { isAITitleEnabled } from "@/lib/functions/conversation-title";
+
+interface AITitlesToggleProps {
+  className?: string;
+}
+
+export const AITitlesToggle = ({ className }: AITitlesToggleProps) => {
+  const [enabled, setEnabled] = useState<boolean>(true);
+
+  useEffect(() => {
+    setEnabled(isAITitleEnabled());
+  }, []);
+
+  const handleSwitchChange = (checked: boolean) => {
+    setEnabled(checked);
+    safeLocalStorage.setItem(STORAGE_KEYS.AI_TITLES_ENABLED, String(checked));
+  };
+
+  return (
+    <div id="ai-titles" className={`space-y-2 ${className}`}>
+      <Header
+        title="AI Conversation Titles"
+        description="Control how conversations are named in your chat history"
+        isMainTitle
+      />
+      <div className="flex items-center justify-between">
+        <div className="flex items-center space-x-3">
+          <div>
+            <Label className="text-sm font-medium">
+              {enabled ? "AI Titles Enabled" : "AI Titles Disabled"}
+            </Label>
+            <p className="text-xs text-muted-foreground mt-1">
+              {enabled
+                ? "New conversations are named by the AI, which costs one short extra request each"
+                : "New conversations are named after their first message"}
+            </p>
+          </div>
+        </div>
+        <Switch
+          checked={enabled}
+          onCheckedChange={handleSwitchChange}
+          title={`Toggle to ${!enabled ? "enable" : "disable"} AI titles`}
+          aria-label={`Toggle to ${enabled ? "disable" : "enable"} AI titles`}
+        />
+      </div>
+    </div>
+  );
+};

--- a/src/pages/settings/components/index.ts
+++ b/src/pages/settings/components/index.ts
@@ -1,3 +1,4 @@
+export * from "./AITitlesToggle";
 export * from "./AlwaysOnTopToggle";
 export * from "./AppIconToggle";
 export * from "./AutostartToggle";

--- a/src/pages/settings/index.tsx
+++ b/src/pages/settings/index.tsx
@@ -1,5 +1,6 @@
 import {
   Theme,
+  AITitlesToggle,
   AlwaysOnTopToggle,
   AppIconToggle,
   AutostartToggle,
@@ -20,6 +21,9 @@ const Settings = () => {
 
       {/* Always On Top Toggle */}
       <AlwaysOnTopToggle />
+
+      {/* AI Conversation Titles Toggle */}
+      <AITitlesToggle />
     </PageLayout>
   );
 };

--- a/src/tests/chat-history.update-title.test.ts
+++ b/src/tests/chat-history.update-title.test.ts
@@ -1,0 +1,66 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockExecute = vi.fn();
+const mockSelect = vi.fn();
+
+vi.mock("@/lib/database/config", () => ({
+  getDatabase: vi.fn(async () => ({ execute: mockExecute, select: mockSelect })),
+}));
+
+vi.mock("@/lib", () => ({
+  safeLocalStorage: {
+    getItem: vi.fn(() => null),
+    setItem: vi.fn(),
+    removeItem: vi.fn(),
+  },
+}));
+
+import { updateConversationTitle } from "@/lib/database/chat-history.action";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockExecute.mockResolvedValue({ rowsAffected: 1, lastInsertId: 0 });
+  mockSelect.mockResolvedValue([]);
+});
+
+describe("updateConversationTitle", () => {
+  it("renames the row without touching updated_at", async () => {
+    await expect(
+      updateConversationTitle("conversation-1", "Signing Key Rotation")
+    ).resolves.toBe(true);
+
+    expect(mockExecute).toHaveBeenCalledTimes(1);
+    const [sql, params] = mockExecute.mock.calls[0];
+    // updated_at is what the chats list sorts and date-groups on. A rename is
+    // not new activity, so touching it would jump the conversation to "now".
+    expect(sql).not.toMatch(/updated_at/i);
+    expect(String(sql).replace(/\s+/g, " ").trim()).toBe(
+      "UPDATE conversations SET title = ? WHERE id = ?"
+    );
+    expect(params).toEqual(["Signing Key Rotation", "conversation-1"]);
+  });
+
+  it("reports false when no row matched", async () => {
+    mockExecute.mockResolvedValue({ rowsAffected: 0, lastInsertId: 0 });
+
+    await expect(
+      updateConversationTitle("deleted-conversation", "Too Late")
+    ).resolves.toBe(false);
+  });
+
+  it.each([
+    ["", "A Title"],
+    ["conversation-1", ""],
+  ])("refuses to write with id %j and title %j", async (id, title) => {
+    await expect(updateConversationTitle(id, title)).resolves.toBe(false);
+    expect(mockExecute).not.toHaveBeenCalled();
+  });
+
+  it("propagates a failed write instead of reporting success", async () => {
+    mockExecute.mockRejectedValue(new Error("database is locked"));
+
+    await expect(
+      updateConversationTitle("conversation-1", "Signing Key Rotation")
+    ).rejects.toThrow(/database is locked/);
+  });
+});

--- a/src/tests/conversation-title.test.ts
+++ b/src/tests/conversation-title.test.ts
@@ -1,0 +1,273 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockFetchAIResponse = vi.fn();
+const mockShouldUseMeetwingsAPI = vi.fn();
+const mockUpdateConversationTitle = vi.fn();
+const mockGetItem = vi.fn();
+
+vi.mock("@/lib/functions/ai-response.function", () => ({
+  fetchAIResponse: (...args: unknown[]) => mockFetchAIResponse(...args),
+}));
+
+vi.mock("@/lib/functions/meetwings.api", () => ({
+  shouldUseMeetwingsAPI: () => mockShouldUseMeetwingsAPI(),
+}));
+
+vi.mock("@/lib/database", () => ({
+  updateConversationTitle: (...args: unknown[]) =>
+    mockUpdateConversationTitle(...args),
+}));
+
+vi.mock("@/lib/storage", () => ({
+  safeLocalStorage: {
+    getItem: (...args: unknown[]) => mockGetItem(...args),
+    setItem: vi.fn(),
+    removeItem: vi.fn(),
+  },
+}));
+
+import {
+  applyAIConversationTitle,
+  generateAIConversationTitle,
+  isAITitleEnabled,
+  MAX_AI_TITLE_LENGTH,
+  parseGeneratedTitle,
+} from "@/lib/functions/conversation-title";
+import { Message } from "@/types";
+
+const MESSAGES: Message[] = [
+  { role: "user", content: "how do I rotate the signing key without downtime" },
+  { role: "assistant", content: "Publish the new key first, then cut over." },
+];
+
+/** Makes fetchAIResponse yield `chunks` like a streaming provider would. */
+function respondWith(...chunks: string[]) {
+  mockFetchAIResponse.mockImplementation(async function* () {
+    for (const chunk of chunks) {
+      yield chunk;
+    }
+  });
+}
+
+let nextId = 0;
+/**
+ * applyAIConversationTitle only ever attempts a given conversation once per
+ * process, so each test needs its own id rather than a shared constant.
+ */
+function freshConversationId(): string {
+  nextId += 1;
+  return `conversation-${nextId}`;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockShouldUseMeetwingsAPI.mockResolvedValue(true);
+  mockUpdateConversationTitle.mockResolvedValue(true);
+  mockGetItem.mockReturnValue(null);
+  respondWith('{"title": "Signing Key Rotation"}');
+});
+
+describe("parseGeneratedTitle", () => {
+  it("reads the title out of a plain JSON response", () => {
+    expect(parseGeneratedTitle('{"title": "Signing Key Rotation"}')).toBe(
+      "Signing Key Rotation"
+    );
+  });
+
+  it("reads the title out of a fenced JSON response", () => {
+    expect(
+      parseGeneratedTitle('```json\n{"title": "Q3 Budget Review"}\n```')
+    ).toBe("Q3 Budget Review");
+  });
+
+  it.each([
+    ['{"title": "\\"Quoted Title\\""}', "Quoted Title"],
+    ['{"title": "## Heading Title"}', "Heading Title"],
+    ['{"title": "Trailing Period."}', "Trailing Period"],
+    ['{"title": "  Padded   Title  "}', "Padded Title"],
+  ])("strips model formatting tics from %s", (raw, expected) => {
+    expect(parseGeneratedTitle(raw)).toBe(expected);
+  });
+
+  it("truncates an over-long title on a word boundary", () => {
+    const long = "Rotating The Production Signing Key Without Any Downtime At All";
+    const title = parseGeneratedTitle(JSON.stringify({ title: long }));
+
+    expect(title).not.toBeNull();
+    expect(title!.length).toBeLessThanOrEqual(MAX_AI_TITLE_LENGTH);
+    // A word-boundary cut, not a cut through the middle of a word.
+    expect(long.split(" ")).toContain(title!.split(" ").pop());
+  });
+
+  it.each([
+    // fetchAIResponse reports failures by yielding a string rather than
+    // throwing, so these are what a failed call actually looks like.
+    "Meetwings API Error: 401 Unauthorized",
+    "Streaming not supported or response body missing",
+    "Failed to parse non-streaming response: Unexpected token",
+    // Malformed or empty model output.
+    '{"title": ""}',
+    '{"title": 42}',
+    "{}",
+    "",
+  ])("rejects %s", (raw) => {
+    expect(parseGeneratedTitle(raw)).toBeNull();
+  });
+
+  it("rejects a response that is far too long to be a title", () => {
+    const rambling = JSON.stringify({ title: "x".repeat(600) });
+    expect(parseGeneratedTitle(rambling)).toBeNull();
+  });
+});
+
+describe("isAITitleEnabled", () => {
+  it("defaults to enabled when nothing is stored", () => {
+    mockGetItem.mockReturnValue(null);
+    expect(isAITitleEnabled()).toBe(true);
+  });
+
+  it('is disabled only by an explicit "false"', () => {
+    mockGetItem.mockReturnValue("false");
+    expect(isAITitleEnabled()).toBe(false);
+  });
+});
+
+describe("generateAIConversationTitle", () => {
+  it("returns the title from a streamed response", async () => {
+    respondWith('{"title": ', '"Signing Key ', 'Rotation"}');
+
+    await expect(generateAIConversationTitle(MESSAGES)).resolves.toBe(
+      "Signing Key Rotation"
+    );
+  });
+
+  it("does not call the AI when there is no provider and no Meetwings API", async () => {
+    mockShouldUseMeetwingsAPI.mockResolvedValue(false);
+
+    await expect(generateAIConversationTitle(MESSAGES)).resolves.toBeNull();
+    expect(mockFetchAIResponse).not.toHaveBeenCalled();
+  });
+
+  it("does not call the AI for a conversation with no text", async () => {
+    await expect(
+      generateAIConversationTitle([{ role: "user", content: "   " }])
+    ).resolves.toBeNull();
+    expect(mockFetchAIResponse).not.toHaveBeenCalled();
+  });
+
+  it("flattens multimodal content instead of stringifying it", async () => {
+    await generateAIConversationTitle([
+      {
+        role: "user",
+        content: [
+          { type: "text", text: "what is in this screenshot" },
+          { type: "image_url", image_url: { url: "data:image/png;base64,AAA" } },
+        ],
+      },
+    ]);
+
+    const { userMessage } = mockFetchAIResponse.mock.calls[0][0];
+    expect(userMessage).toContain("what is in this screenshot");
+    expect(userMessage).not.toContain("[object Object]");
+    expect(userMessage).not.toContain("base64");
+  });
+
+  it("returns null when the request throws", async () => {
+    mockFetchAIResponse.mockImplementation(async function* () {
+      throw new Error("network down");
+      // eslint-disable-next-line no-unreachable
+      yield "";
+    });
+
+    await expect(generateAIConversationTitle(MESSAGES)).resolves.toBeNull();
+  });
+});
+
+describe("applyAIConversationTitle", () => {
+  it("stores the generated title and announces it", async () => {
+    const id = freshConversationId();
+    const events: CustomEvent[] = [];
+    const listener = (event: Event) => events.push(event as CustomEvent);
+    window.addEventListener("conversation-title-updated", listener);
+
+    try {
+      await expect(applyAIConversationTitle(id, MESSAGES)).resolves.toBe(
+        "Signing Key Rotation"
+      );
+    } finally {
+      window.removeEventListener("conversation-title-updated", listener);
+    }
+
+    expect(mockUpdateConversationTitle).toHaveBeenCalledWith(
+      id,
+      "Signing Key Rotation"
+    );
+    expect(events).toHaveLength(1);
+    expect(events[0].detail).toEqual({ id, title: "Signing Key Rotation" });
+  });
+
+  it("attempts a given conversation only once", async () => {
+    const id = freshConversationId();
+
+    await applyAIConversationTitle(id, MESSAGES);
+    await expect(applyAIConversationTitle(id, MESSAGES)).resolves.toBeNull();
+
+    expect(mockFetchAIResponse).toHaveBeenCalledTimes(1);
+    expect(mockUpdateConversationTitle).toHaveBeenCalledTimes(1);
+  });
+
+  it("spends only one request when two callers race the same conversation", async () => {
+    const id = freshConversationId();
+
+    await Promise.all([
+      applyAIConversationTitle(id, MESSAGES),
+      applyAIConversationTitle(id, MESSAGES),
+    ]);
+
+    expect(mockFetchAIResponse).toHaveBeenCalledTimes(1);
+  });
+
+  it("does nothing when the feature is disabled", async () => {
+    mockGetItem.mockReturnValue("false");
+
+    await expect(
+      applyAIConversationTitle(freshConversationId(), MESSAGES)
+    ).resolves.toBeNull();
+    expect(mockFetchAIResponse).not.toHaveBeenCalled();
+    expect(mockUpdateConversationTitle).not.toHaveBeenCalled();
+  });
+
+  it("leaves the fallback title in place when generation fails", async () => {
+    respondWith("Meetwings API Error: 401 Unauthorized");
+
+    await expect(
+      applyAIConversationTitle(freshConversationId(), MESSAGES)
+    ).resolves.toBeNull();
+    expect(mockUpdateConversationTitle).not.toHaveBeenCalled();
+  });
+
+  it("does not announce a title when the row is gone", async () => {
+    mockUpdateConversationTitle.mockResolvedValue(false);
+    const events: Event[] = [];
+    const listener = (event: Event) => events.push(event);
+    window.addEventListener("conversation-title-updated", listener);
+
+    try {
+      await expect(
+        applyAIConversationTitle(freshConversationId(), MESSAGES)
+      ).resolves.toBeNull();
+    } finally {
+      window.removeEventListener("conversation-title-updated", listener);
+    }
+
+    expect(events).toHaveLength(0);
+  });
+
+  it("does not reject when the database write throws", async () => {
+    mockUpdateConversationTitle.mockRejectedValue(new Error("database is locked"));
+
+    await expect(
+      applyAIConversationTitle(freshConversationId(), MESSAGES)
+    ).resolves.toBeNull();
+  });
+});

--- a/src/tests/conversation-title.test.ts
+++ b/src/tests/conversation-title.test.ts
@@ -172,6 +172,30 @@ describe("generateAIConversationTitle", () => {
     expect(userMessage).not.toContain("base64");
   });
 
+  it("leaves the request running for a well-formed response", async () => {
+    await generateAIConversationTitle(MESSAGES);
+
+    expect(mockFetchAIResponse.mock.calls[0][0].signal.aborted).toBe(false);
+  });
+
+  it("cancels a response that blows past any plausible title", async () => {
+    let chunksPulled = 0;
+    mockFetchAIResponse.mockImplementation(async function* () {
+      while (true) {
+        chunksPulled += 1;
+        yield "x".repeat(300);
+      }
+    });
+
+    await expect(generateAIConversationTitle(MESSAGES)).resolves.toBeNull();
+
+    expect(chunksPulled).toBe(2);
+    // Abandoning the loop is not enough on its own: that tears the generator
+    // down with .return(), which skips fetchAIResponse's reader.cancel() and
+    // leaves the HTTP stream open. The abort is what cancels the request.
+    expect(mockFetchAIResponse.mock.calls[0][0].signal.aborted).toBe(true);
+  });
+
   it("returns null when the request throws", async () => {
     mockFetchAIResponse.mockImplementation(async function* () {
       throw new Error("network down");


### PR DESCRIPTION
## Problem

A conversation's name in the Chats list was the raw first user message, trimmed but not truncated (`generateConversationTitle` returned `userMessage.trim()`). In practice the list showed whole paragraphs clipped by `line-clamp-1`, `Meeting transcript - 7/27/2026`, or a quick-action label like "What should I say?".

The summarizer already produced a good title (`SummarizationResult.title`), but it was stored in `meeting_context` and never reached `conversations.title`.

## What changed

A new conversation now gets one short background AI call that names it. The generated title replaces the fallback in place, after the save has already landed.

- **`src/lib/functions/conversation-title.ts`** (new) — prompt, response parsing, and `applyAIConversationTitle`, a one-shot-per-conversation orchestrator that writes the title and announces it via a `conversation-title-updated` event.
- **`updateConversationTitle(id, title)`** in `chat-history.action.ts` — a single `UPDATE`, deliberately not touching `updated_at`. The chats list sorts and date-groups on that column, so bumping it would jump a conversation to "now" just because a background rename landed.
- **Trigger sites** — the three places that create a conversation (normal save, meeting-assist quick action, transcript autosave) plus system audio capture. Each fires only for a conversation that had no title, so an existing name is never overwritten — the same rule as #22.
- **Staleness handling** — `useCompletion`'s metadata cache, `useSystemAudio`'s local conversation state, and `useHistory`'s list all listen for the rename, so a save that was in flight when the title landed can't write the fallback back over it.
- **Settings toggle**, default on, since each new conversation costs an extra request.

## Why JSON, not a bare title line

`fetchAIResponse` reports failures by *yielding* an error string rather than throwing — `Meetwings API Error: 401 Unauthorized`, `Streaming not supported or response body missing`. Under a bare-text contract those become the conversation's title. Requiring a `{"title": "..."}` envelope makes every such response fail to parse and fall through to the existing fallback. Tests pin each of those real error strings as rejected.

## Fallback behaviour

Unchanged. Every existing title path stays exactly as it was and still runs first; the AI title only replaces its result afterward. No provider configured, request failed, unparseable response, feature disabled, or row deleted mid-flight — the conversation keeps the name it already had.

## Not covered

`useChatCompletion` (the `/chats/view/:id` page) only continues conversations that already exist and already have a title, so there is nothing to name there.

## Verification

- `src/tests/conversation-title.test.ts` — 29 cases: parsing, formatting-tic stripping, word-boundary truncation, rejection of each real `fetchAIResponse` error string, one-attempt-per-conversation including two callers racing, disabled toggle, deleted row, DB write failure.
- `src/tests/chat-history.update-title.test.ts` — the `UPDATE` leaves `updated_at` alone, reports false on no match, refuses empty input, propagates a failed write.
- Full suite: 235 passed, 2 skipped. `npx tsc --noEmit` clean. `npm run build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
