### PR TITLE
chore: release 1.0.2

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides context for AI assistants (like Claude) when working on the M
 
 Meetwings is based on [Pluely](https://github.com/iamsrikanthnani/pluely) by [Srikanth Nani](https://www.srikanthnani.com/), providing your invisible AI wingman for every meeting.
 
-- **Version**: 0.1.8
+- **Version**: 1.0.2
 - **License**: GPL-3.0
 - **Size**: ~10MB (27x smaller than commercial alternatives)
 - **Platforms**: Windows, macOS, Linux

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meetwings",
-  "version": "1.0.0",
+  "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meetwings",
-      "version": "1.0.0",
+      "version": "1.0.2",
       "license": "GPL-3.0",
       "dependencies": {
         "@bany/curl-to-json": "^1.2.8",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "meetwings",
   "private": false,
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Your invisible AI wingman for meetings and conversations. An open-source, privacy-first AI assistant that provides real-time support during meetings, interviews, and conversations - completely undetectable.",
   "author": {
     "name": "Kevin Morgan-Rothschild",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3122,7 +3122,7 @@ dependencies = [
 
 [[package]]
 name = "meetwings"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "meetwings"
-version = "1.0.1"
+version = "1.0.2"
 description = "Your invisible AI wingman for meetings and conversations. An open-source, privacy-first AI assistant that provides real-time support during meetings, interviews, and conversations - completely undetectable."
 authors = ["Kevin Morgan-Rothschild <kmorganr@gmail.com>"]
 license = "GPL-3.0"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Meetwings",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "identifier": "com.meetwings.app",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
## What

Version bump only, no source changes.

| File | 1.0.1 → 1.0.2 |
|---|---|
| `package.json` | ✅ |
| `package-lock.json` | ✅ |
| `src-tauri/tauri.conf.json` | ✅ |
| `src-tauri/Cargo.toml` | ✅ |
| `src-tauri/Cargo.lock` | ✅ |
| `CLAUDE.md` | 0.1.8 → 1.0.2 (was stale by two releases) |

## Why now

- First release built by the workflow from #28, so it's the first one to carry the version-less asset names (`Meetwings-windows-x64-setup.exe`, etc.). The website PR is blocked on this landing.
- Gives the AI conversation titles from #26 a version of their own. That code was built and uploaded, but *over* v1.0.1's assets, so no existing user was ever offered it as an update.

## After merge

1. `publish` builds all four targets and creates a **draft** release `Meetwings v1.0.2` / tag `app-v1.0.2`. Nothing is public yet.
2. Verify the draft has both sets of assets — versioned (`Meetwings_1.0.2_x64-setup.exe`) and stable (`Meetwings-windows-x64-setup.exe`).
3. Publish it: `gh release edit app-v1.0.2 --draft=false --latest`
4. Then merge kmorgan-r/meetwings-website#6, whose links only resolve once step 3 is done.

Auto-update for existing 1.0.1 users depends on `https://meetwings.com/api/update` reporting 1.0.2 — that endpoint isn't in this repo and hasn't been checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)