### PR TITLE
fix: make the stable-name upload actually run, and serialize publish runs

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,6 +5,14 @@ on:
     branches:
       - main
 
+# GitHub dispatched two identical runs for commit 88d6b84, and both raced to
+# upload the same asset names - one won, the other died on "already_exists".
+# Serialize instead of cancelling: a cancelled run can leave a release
+# half-populated, and a duplicate that merely repeats the uploads is harmless.
+concurrency:
+  group: publish-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   # This workflow runs on every push to main, but the release it targets is
   # named after the version in package.json. Merging anything without bumping
@@ -128,19 +136,29 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          shopt -s nullglob
           version=$(node -p "require('./package.json').version")
           mkdir -p _aliases
-          for pair in ${{ matrix.bundles }}; do
+          # Split the pair list with pathname expansion off. Every entry
+          # contains a `*`, so bash tries to glob the whole "<glob>:<name>"
+          # word, which matches no file - and under `nullglob` a non-matching
+          # pattern is dropped from the list outright, so the loop ran zero
+          # times and uploaded nothing while still exiting 0.
+          set -f
+          pairs=( ${{ matrix.bundles }} )
+          set +f
+          for pair in "${pairs[@]}"; do
             src="${pair%%:*}"
             dest="${pair##*:}"
             matches=( $src )
             # Fail loudly: a silently missing copy is a dead download button on
-            # the website, which nothing else would catch.
-            if [ ${#matches[@]} -ne 1 ]; then
-              echo "::error::expected exactly 1 bundle matching $src, found ${#matches[@]}"
+            # the website, which nothing else would catch. Without nullglob a
+            # pattern that matches nothing stays literal, so the -e test is what
+            # catches that case.
+            if [ ${#matches[@]} -ne 1 ] || [ ! -e "${matches[0]}" ]; then
+              echo "::error::expected exactly 1 bundle matching $src, got: ${matches[*]}"
               exit 1
             fi
             cp "${matches[0]}" "_aliases/$dest"
             gh release upload "app-v$version" "_aliases/$dest" --clobber
+            echo "uploaded $dest"
           done


### PR DESCRIPTION
## The bug

The alias step added in #28 silently uploaded nothing on the 1.0.2 build. It exited 0 with no output, so nothing flagged it — the draft release came out with only Tauri's versioned filenames, and every download button on meetwings.com 404s as a result.

Cause is one line:

```bash
shopt -s nullglob
for pair in ${{ matrix.bundles }}; do
```

Each matrix entry is a `<glob>:<name>` pair, so every word in that list contains a `*`. Bash applies pathname expansion to the list, tries to glob the whole `src-tauri/.../deb/*.deb:Meetwings-linux-x64.deb` word, matches no file — and under `nullglob` a non-matching pattern is **removed from the list entirely**. Zero iterations.

Reproduced:

```
$ B="b/*.deb:Alias.deb"
--- with nullglob (what shipped) ---
iterations=0
--- without nullglob ---
iter: b/*.deb:Alias.deb
iterations=1
```

The `${#matches[@]} -ne 1` guard was meant to catch a missing bundle, but it lives *inside* the loop that never ran.

## The fix

- Split the pair list with `set -f` so the `<glob>:<name>` words aren't themselves globbed.
- Drop `nullglob`. Without it a pattern matching nothing stays literal, so a `[ ! -e "${matches[0]}" ]` test catches that case — a real failure instead of a silent skip.
- `echo "uploaded $dest"` per file, so an empty run is visible in the log rather than indistinguishable from success.

Both the success path (3 uploads from 3 pairs) and the missing-bundle path (`::error::` + exit 1) verified locally against the real Linux matrix string.

## Also: duplicate runs

GitHub dispatched **two identical publish runs** for `88d6b84` (30362809334 and 30362810291, same headSha, same second). They raced to upload the same filenames and the loser failed the Windows job on `Validation Failed: {"resource":"ReleaseAsset","code":"already_exists"}`.

Added a `concurrency` group per ref. Serializing rather than `cancel-in-progress: true`: a cancelled run can leave a release half-populated, while a duplicate that merely repeats the uploads is harmless.

## Release state

The 1.0.2 draft has been backfilled by hand with all 7 alias assets, so it no longer depends on this PR to be publishable. This PR is what keeps 1.0.3 onward from needing that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)